### PR TITLE
Fix warnings about struct/class mismatch

### DIFF
--- a/include/boost/smart_ptr/detail/array_allocator.hpp
+++ b/include/boost/smart_ptr/detail/array_allocator.hpp
@@ -20,7 +20,7 @@ namespace boost {
         struct ms_noinit_tag { };
 
         template<class T>
-        class ms_allocator_state;
+        struct ms_allocator_state;
 
         template<class T>
         struct ms_allocator_state<T[]> {


### PR DESCRIPTION
ms_allocator_state template was declared as class but its specializations were as structs. This caused Clang 3.2 warnings. The commit changes ms_allocator_state declaration to struct to fix that.
