### PR TITLE
Fix warnings on gcc 4.4

### DIFF
--- a/include/boost/smart_ptr/detail/sp_forward.hpp
+++ b/include/boost/smart_ptr/detail/sp_forward.hpp
@@ -25,10 +25,23 @@ namespace detail
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
+#if defined( __GNUC__ ) && __GNUC__ * 100 + __GNUC_MINOR__ <= 404
+
+// GCC 4.4 supports an outdated version of rvalue references and creates a copy of the forwarded object.
+// This results in warnings 'returning reference to temporary'. Therefore we use a special version similar to std::forward.
+template< class T > T&& sp_forward( T && t ) BOOST_NOEXCEPT
+{
+    return t;
+}
+
+#else
+
 template< class T > T&& sp_forward( T & t ) BOOST_NOEXCEPT
 {
     return static_cast< T&& >( t );
 }
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Added a special version of sp_forward for an outdated version of rvalue references supported by gcc 4.4. The compiler would create a temporary and return an rvalue reference to it in the original code. This resulted in warnings about 'returning reference to temporary'.

The added version is similar to std::forward on that compiler, except it doesn't prohibit template argument deduction (which is in line with the original sp_forward).
