### PR TITLE
Fix compilation problems with clang

### DIFF
--- a/include/boost/smart_ptr/detail/sp_forward.hpp
+++ b/include/boost/smart_ptr/detail/sp_forward.hpp
@@ -25,7 +25,7 @@ namespace detail
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-#if defined( __GNUC__ ) && __GNUC__ * 100 + __GNUC_MINOR__ <= 404
+#if defined( BOOST_GCC ) && __GNUC__ * 100 + __GNUC_MINOR__ <= 404
 
 // GCC 4.4 supports an outdated version of rvalue references and creates a copy of the forwarded object.
 // This results in warnings 'returning reference to temporary'. Therefore we use a special version similar to std::forward.


### PR DESCRIPTION
Apparently, clang presents itself as gcc 4.2 even though it supports the final version of rvalue references. Restrict the workaround to gcc only.
