### PR TITLE
Resolved issue were variable var in a lambda test conflicted with struct...

### DIFF
--- a/include/boost/smart_ptr/detail/yield_k.hpp
+++ b/include/boost/smart_ptr/detail/yield_k.hpp
@@ -98,7 +98,14 @@ inline void yield( unsigned k )
 
 #elif defined( BOOST_HAS_PTHREADS )
 
+#ifdef _AIX
+#define var xvarx
+#endif
 #include <sched.h>
+#ifdef _AIX
+#undef var
+#endif
+
 #include <time.h>
 
 namespace boost


### PR DESCRIPTION
... var in AIX's var.h.

In ../boost/lambda/detail/lambda_functor_base.hpp there is variable called var that conflicts with an AIX system variable. Defining var and later undefining it frees that variable name.
