### PR TITLE
Allow weak_from_raw to be called alone

### DIFF
--- a/include/boost/smart_ptr/enable_shared_from_raw.hpp
+++ b/include/boost/smart_ptr/enable_shared_from_raw.hpp
@@ -55,7 +55,7 @@ private:
 
     void init_weak_once() const
     {
-        if( weak_this_.expired() )
+        if( weak_this_._empty() )
         {
             shared_this_.reset( static_cast<void*>(0), detail::esft2_deleter_wrapper() );
             weak_this_ = shared_this_;

--- a/include/boost/smart_ptr/enable_shared_from_raw.hpp
+++ b/include/boost/smart_ptr/enable_shared_from_raw.hpp
@@ -123,6 +123,7 @@ template<typename T>
 boost::weak_ptr<T> weak_from_raw(T *p)
 {
     BOOST_ASSERT(p != 0);
+    p->enable_shared_from_raw::init_weak_once();
     boost::weak_ptr<T> result;
     result._internal_aliasing_assign(p->enable_shared_from_raw::weak_this_, p);
     return result;

--- a/test/enable_shared_from_raw_test.cpp
+++ b/test/enable_shared_from_raw_test.cpp
@@ -17,19 +17,23 @@
 
 
 struct X: public boost::enable_shared_from_raw
-{};
+{
+	~X() { BOOST_TEST(boost::weak_from_raw(this).expired()); }
+};
 
 void basic_weak_from_raw_test()
 {
     X *p(new X);
     boost::weak_ptr<X> weak = boost::weak_from_raw(p);
-    BOOST_TEST(weak.expired());
-    boost::shared_ptr<X> shared(p);
-    weak = boost::weak_from_raw(p);
     BOOST_TEST(weak.expired() == false);
-    boost::shared_ptr<X> shared2(weak);
-    BOOST_TEST((shared < shared2 || shared2 < shared) == false);
-    BOOST_TEST(shared.get() == p);
+    {
+        boost::shared_ptr<X> shared(p);
+        BOOST_TEST(weak.expired() == false);
+        boost::shared_ptr<X> shared2(weak);
+        BOOST_TEST((shared < shared2 || shared2 < shared) == false);
+        BOOST_TEST(shared.get() == p);
+    }
+    BOOST_TEST(weak.expired());
 }
 
 int main()


### PR DESCRIPTION
Currently weak_from_raw fails unless shared_from_raw has been called previously.  This doesn't seem like reasonable behaviour, especially when only a weak_ptr is desired and the overhead of creating a shared_ptr and degrading it back to a weak_ptr again seems silly.