### PR TITLE
Avoid potential conflict between AIX's and Lambda's var.

### DIFF
--- a/include/boost/smart_ptr/detail/yield_k.hpp
+++ b/include/boost/smart_ptr/detail/yield_k.hpp
@@ -98,7 +98,13 @@ inline void yield( unsigned k )
 
 #elif defined( BOOST_HAS_PTHREADS )
 
+#ifndef _AIX
 #include <sched.h>
+#else
+    // AIX's sched.h defines ::var which sometimes conflicts with Lambda's var
+        extern "C" int sched_yield(void);
+#endif
+
 #include <time.h>
 
 namespace boost


### PR DESCRIPTION
In ../boost/lambda/detail/lambda_functor_base.hpp there is variable called var that conflicts with an AIX system variable. The entire file (sched.h) does not need to be included only the one function it uses (sched_yield).
