### PR TITLE
Added __declspec(dllimport) for Sleep using clang on Windows.

### DIFF
--- a/include/boost/smart_ptr/detail/yield_k.hpp
+++ b/include/boost/smart_ptr/detail/yield_k.hpp
@@ -60,7 +60,11 @@ namespace detail
 {
 
 #if !defined( BOOST_USE_WINDOWS_H ) && !BOOST_PLAT_WINDOWS_RUNTIME
+#if BOOST_COMP_CLANG
+  extern "C" __declspec(dllimport) void __stdcall Sleep( unsigned long ms );
+#else
   extern "C" void __stdcall Sleep( unsigned long ms );
+#endif
 #endif
 
 inline void yield( unsigned k )


### PR DESCRIPTION
This fixes a problem with the latest clang built from source. It also works fine with previous versions of clang on Windows. I will test this again once clang 3.7 is official but since it works with clang 3.4.1, clang 3.5.2, and clang 3.6.1 on Windows I doubt it will cause any problems once clang 3.7 on Windows is officially released. Needless to say this does not affect clang outside of Windows at all.