### PR TITLE
Change to Sleep declaration for clang on Windows to match Windows imp…

### DIFF
--- a/include/boost/smart_ptr/detail/yield_k.hpp
+++ b/include/boost/smart_ptr/detail/yield_k.hpp
@@ -27,6 +27,10 @@
 #include <boost/config.hpp>
 #include <boost/predef.h>
 
+#if defined __MINGW32__
+#include <_mingw.h>
+#endif
+
 #if BOOST_PLAT_WINDOWS_RUNTIME
 #include <thread>
 #endif
@@ -60,10 +64,10 @@ namespace detail
 {
 
 #if !defined( BOOST_USE_WINDOWS_H ) && !BOOST_PLAT_WINDOWS_RUNTIME
-#if BOOST_COMP_CLANG
-  extern "C" __declspec(dllimport) void __stdcall Sleep( unsigned long ms );
-#else
+#if !BOOST_COMP_CLANG || (defined __MINGW32__ && !defined __MINGW64_VERSION_MAJOR)
   extern "C" void __stdcall Sleep( unsigned long ms );
+#else
+  extern "C" __declspec(dllimport) void __stdcall Sleep( unsigned long ms );
 #endif
 #endif
 

--- a/include/boost/smart_ptr/detail/yield_k.hpp
+++ b/include/boost/smart_ptr/detail/yield_k.hpp
@@ -27,10 +27,6 @@
 #include <boost/config.hpp>
 #include <boost/predef.h>
 
-#if defined __MINGW32__
-#include <_mingw.h>
-#endif
-
 #if BOOST_PLAT_WINDOWS_RUNTIME
 #include <thread>
 #endif
@@ -64,10 +60,15 @@ namespace detail
 {
 
 #if !defined( BOOST_USE_WINDOWS_H ) && !BOOST_PLAT_WINDOWS_RUNTIME
-#if !BOOST_COMP_CLANG || (defined __MINGW32__ && !defined __MINGW64_VERSION_MAJOR)
+#if !BOOST_COMP_CLANG || !defined __MINGW32__
+  extern "C" void __stdcall Sleep( unsigned long ms );
+#else
+#include <_mingw.h>
+#if !defined __MINGW64_VERSION_MAJOR
   extern "C" void __stdcall Sleep( unsigned long ms );
 #else
   extern "C" __declspec(dllimport) void __stdcall Sleep( unsigned long ms );
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
…lementation being used.

After discussions on the clang mailing list the change above has been made to sync the declaration of Sleep to the Windows implementation being used. With clang/mingw the original declaration is fine but otherwise for clang __declspec(dllimport) should be added to the declaration. The case where clang issues an error is arcane ( details of it can be provided if requested ) so syncing the declaration with the Windows implementation is safest. I have already made my appeal on the clang mailing list to stop issuing an error in this situation ( neither gcc or vc++ does so ).