### PR TITLE
Disable explicit operator bool on Oracle C++

### DIFF
--- a/include/boost/smart_ptr/detail/operator_bool.hpp
+++ b/include/boost/smart_ptr/detail/operator_bool.hpp
@@ -6,7 +6,8 @@
 //  See accompanying file LICENSE_1_0.txt or copy at
 //  http://www.boost.org/LICENSE_1_0.txt
 
-#if !defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS ) && !defined( BOOST_NO_CXX11_NULLPTR )
+#if !defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS ) && !defined( BOOST_NO_CXX11_NULLPTR )\
+    && !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5130))
 
     explicit operator bool () const BOOST_NOEXCEPT
     {


### PR DESCRIPTION
Although Oracle supports this syntax, advanced usage such as:

if(my_shared_ptr && x)

Fail.  Attempts to wokaround by adding additional operator overloads have so far failed.