### PR TITLE
Added shared_ptr aliasing move constructor.

### DIFF
--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -642,6 +642,14 @@ public:
         return *this;
     }
 
+    // aliasing move
+    template<class Y>
+    shared_ptr( shared_ptr<Y> && r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn()
+    {
+        pn.swap( r.pn );
+        r.px = 0;
+    }
+
 #endif
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )

--- a/shared_ptr.htm
+++ b/shared_ptr.htm
@@ -139,6 +139,8 @@ void bad()
 
       template&lt;class Y&gt; <a href="#aliasing_constructor" >shared_ptr</a>(shared_ptr&lt;Y&gt; const &amp; r, element_type * p); // never throws
 
+      template&lt;class Y&gt; <a href="#aliasing_move_constructor" >shared_ptr</a>(shared_ptr&lt;Y&gt; &amp;&amp; r, element_type * p); // never throws
+
       template&lt;class Y&gt; explicit <a href="#weak_ptr_constructor" >shared_ptr</a>(<a href="weak_ptr.htm" >weak_ptr</a>&lt;Y&gt; const &amp; r);
 
       template&lt;class Y&gt; explicit <a href="#auto_ptr_constructor" >shared_ptr</a>(std::auto_ptr&lt;Y&gt; &amp; r);
@@ -350,6 +352,16 @@ template&lt;class Y&gt; shared_ptr(shared_ptr&lt;Y&gt; &amp;&amp; r); // never t
             <p><b>Effects:</b> constructs a <code>shared_ptr</code> that <em>shares ownership</em> with
                 <code>r</code> and stores <code>p</code>.</p>
             <p><b>Postconditions:</b> <code>get() == p &amp;&amp; use_count() == r.use_count()</code>.</p>
+            <p><b>Throws:</b> nothing.</p>
+        </blockquote>
+        <h3 id="aliasing_move_constructor">aliasing move constructor</h3>
+        <pre>template&lt;class Y&gt; shared_ptr(shared_ptr&lt;Y&gt; &amp;&amp; r, element_type * p); // never throws</pre>
+        <blockquote>
+            <p>
+                <b>Effects:</b> Move-constructs a <code>shared_ptr</code> from <code>r</code>, while
+                storing <code>p</code> instead.
+            </p>
+            <p><b>Postconditions:</b> <code>get() == p</code> and <code>use_count()</code> equals the old count of <code>r</code>. <code>r</code> is <em>empty</em> and <code>r.get() == 0</code>.</p>
             <p><b>Throws:</b> nothing.</p>
         </blockquote>
         <h3 id="weak_ptr_constructor">weak_ptr constructor</h3>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -34,6 +34,7 @@ import testing ;
           [ run shared_ptr_alias_test.cpp ]
           [ run shared_ptr_rv_test.cpp ]
           [ run shared_ptr_move_test.cpp ]
+          [ run shared_ptr_alias_move_test.cpp ]
           [ compile-fail shared_ptr_pv_fail.cpp ]
           [ run sp_unary_addr_test.cpp ]
           [ compile-fail scoped_ptr_eq_fail.cpp ]

--- a/test/shared_ptr_alias_move_test.cpp
+++ b/test/shared_ptr_alias_move_test.cpp
@@ -1,0 +1,105 @@
+#include <boost/config.hpp>
+
+//  shared_ptr_alias_move_test.cpp
+//
+//  Copyright (c) 2007 Peter Dimov
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <boost/detail/lightweight_test.hpp>
+#include <boost/shared_ptr.hpp>
+#include <utility>
+
+#if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+struct X
+{
+    static long instances;
+
+    int v_;
+
+    explicit X( int v ): v_( v )
+    {
+        ++instances;
+    }
+
+    ~X()
+    {
+        v_ = 0;
+        --instances;
+    }
+
+private:
+    X( X const & );
+    X & operator=( X const & );
+};
+
+long X::instances = 0;
+
+int main()
+{
+    BOOST_TEST( X::instances == 0 );
+
+    {
+        boost::shared_ptr< X > p( new X( 5 ) );
+        BOOST_TEST( X::instances == 1 );
+        BOOST_TEST( p.unique() );
+        BOOST_TEST( p->v_ == 5 );
+
+        boost::shared_ptr< X > p2( std::move( p ), p.get() );
+        BOOST_TEST( X::instances == 1 );
+        BOOST_TEST( p.get() == 0 );
+        BOOST_TEST( p2.unique() );
+        BOOST_TEST( p2->v_ == 5 );
+
+        boost::shared_ptr< int const > p3( std::move( p2 ), &p2->v_ );
+        BOOST_TEST( X::instances == 1 );
+        BOOST_TEST( p2.get() == 0 );
+        BOOST_TEST( p3.unique() );
+        BOOST_TEST( *p3 == 5 );
+
+        p3.reset();
+        BOOST_TEST( X::instances == 0 );
+    }
+
+    {
+        boost::shared_ptr< X > p( new X( 5 ) );
+        BOOST_TEST( X::instances == 1 );
+        BOOST_TEST( p.unique() );
+        BOOST_TEST( p->v_ == 5 );
+
+        {
+            boost::shared_ptr< X > p2(p);
+            BOOST_TEST( X::instances == 1 );
+            BOOST_TEST( p.get() == p2.get() );
+            BOOST_TEST( p.use_count() == 2 );
+            BOOST_TEST( p2.use_count() == 2 );
+
+            boost::shared_ptr< int const > p3( std::move( p2 ), &p2->v_ );
+            BOOST_TEST( X::instances == 1 );
+            BOOST_TEST( p.use_count() == 2 );
+            BOOST_TEST( p2.use_count() == 0 );
+            BOOST_TEST( p2.get() == 0 );
+            BOOST_TEST( p3.use_count() == 2 );
+            BOOST_TEST( p3.get() == &p->v_ );
+        }
+
+        BOOST_TEST( X::instances == 1 );
+        BOOST_TEST( p.unique() );
+        BOOST_TEST( p->v_ == 5 );
+    }
+
+    return boost::report_errors();
+}
+
+#else // defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+int main()
+{
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
As per discussion in http://article.gmane.org/gmane.comp.lib.boost.devel/263684; this seems like something that should exist even though use cases are slim.