### PR TITLE
Support MSVC-7.1/ intrin.h available >= MSVC-8.0

### DIFF
--- a/include/boost/smart_ptr/detail/sp_interlocked.hpp
+++ b/include/boost/smart_ptr/detail/sp_interlocked.hpp
@@ -22,7 +22,7 @@
 // BOOST_SP_HAS_INTRIN_H
 
 // VC9 has intrin.h, but it collides with <utility>
-#if defined( BOOST_MSVC ) && BOOST_MSVC >= 1400
+#if defined( BOOST_MSVC ) && BOOST_MSVC >= 1600
 
 # define BOOST_SP_HAS_INTRIN_H
 

--- a/include/boost/smart_ptr/detail/sp_interlocked.hpp
+++ b/include/boost/smart_ptr/detail/sp_interlocked.hpp
@@ -22,7 +22,7 @@
 // BOOST_SP_HAS_INTRIN_H
 
 // VC9 has intrin.h, but it collides with <utility>
-#if defined( BOOST_MSVC ) && BOOST_MSVC >= 1600
+#if defined( BOOST_MSVC ) && BOOST_MSVC >= 1400
 
 # define BOOST_SP_HAS_INTRIN_H
 
@@ -110,6 +110,17 @@ extern "C" long __cdecl _InterlockedDecrement( long volatile * );
 extern "C" long __cdecl _InterlockedCompareExchange( long volatile *, long, long );
 extern "C" long __cdecl _InterlockedExchange( long volatile *, long );
 extern "C" long __cdecl _InterlockedExchangeAdd( long volatile *, long );
+
+# if defined( BOOST_MSVC ) && BOOST_MSVC == 1310
+//From MSDN, Visual Studio .NET 2003 spedific: To declare one of the interlocked functions
+//for use as an intrinsic, the function must be declared with the leading underscore and
+//the new function must appear in a #pragma intrinsic statement.
+#  pragma intrinsic( _InterlockedIncrement )
+#  pragma intrinsic( _InterlockedDecrement )
+#  pragma intrinsic( _InterlockedCompareExchange )
+#  pragma intrinsic( _InterlockedExchange )
+#  pragma intrinsic( _InterlockedExchangeAdd )
+# endif
 
 #endif
 


### PR DESCRIPTION
-> MSVC 7.1 has no intrin.h and needs to use "#pragma intrinsic".
-> intrin.h available since Visual 2005