### PR TITLE
Suppress weak vtables warnings

### DIFF
--- a/include/boost/smart_ptr/bad_weak_ptr.hpp
+++ b/include/boost/smart_ptr/bad_weak_ptr.hpp
@@ -36,6 +36,11 @@ namespace boost
 # pragma option push -pc
 #endif
 
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 class bad_weak_ptr: public std::exception
 {
 public:
@@ -45,6 +50,10 @@ public:
         return "tr1::bad_weak_ptr";
     }
 };
+
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#endif
 
 #if defined(__BORLANDC__) && __BORLANDC__ <= 0x564
 # pragma option pop

--- a/include/boost/smart_ptr/detail/sp_counted_base_clang.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_clang.hpp
@@ -58,6 +58,11 @@ inline boost::int_least32_t atomic_conditional_increment( atomic_int_least32_t *
     }    
 }
 
+#if defined(__clang__)
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
+
 class sp_counted_base
 {
 private:
@@ -132,6 +137,10 @@ public:
         return __c11_atomic_load( const_cast< atomic_int_least32_t* >( &use_count_ ), __ATOMIC_ACQUIRE );
     }
 };
+
+#if defined(__clang__)
+# pragma clang diagnostic pop
+#endif
 
 } // namespace detail
 


### PR DESCRIPTION
Fixes following warnings:
```
In file included from qi/actions2.cpp:20:
In file included from ../../../boost/spirit/include/qi.hpp:16:
In file included from ../../../boost/spirit/home/qi.hpp:28:
In file included from ../../../boost/spirit/home/qi/string.hpp:15:
In file included from ../../../boost/spirit/home/qi/string/symbols.hpp:30:
In file included from ../../../boost/shared_ptr.hpp:17:
In file included from ../../../boost/smart_ptr/shared_ptr.hpp:28:
In file included from ../../../boost/smart_ptr/detail/shared_count.hpp:29:
In file included from ../../../boost/smart_ptr/detail/sp_counted_base.hpp:45:
../../../boost/smart_ptr/detail/sp_counted_base_clang.hpp:61:7: warning: 'sp_counted_base' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Wweak-vtables]
class sp_counted_base
      ^
In file included from qi/actions2.cpp:20:
In file included from ../../../boost/spirit/include/qi.hpp:16:
In file included from ../../../boost/spirit/home/qi.hpp:28:
In file included from ../../../boost/spirit/home/qi/string.hpp:15:
In file included from ../../../boost/spirit/home/qi/string/symbols.hpp:30:
In file included from ../../../boost/shared_ptr.hpp:17:
In file included from ../../../boost/smart_ptr/shared_ptr.hpp:28:
In file included from ../../../boost/smart_ptr/detail/shared_count.hpp:28:
../../../boost/smart_ptr/bad_weak_ptr.hpp:39:7: warning: 'bad_weak_ptr' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Wweak-vtables]
class bad_weak_ptr: public std::exception
      ^
```