### PR TITLE
Use throw() when noexcept is not available.

### DIFF
--- a/include/boost/pointer_cast.hpp
+++ b/include/boost/pointer_cast.hpp
@@ -62,7 +62,7 @@ using std::dynamic_pointer_cast;
 using std::const_pointer_cast;
 
 //reinterpret_pointer_cast overload for std::shared_ptr
-template<class T, class U> std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U> & r ) BOOST_NOEXCEPT
+template<class T, class U> std::shared_ptr<T> reinterpret_pointer_cast(const std::shared_ptr<U> & r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) reinterpret_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -73,7 +73,7 @@ template<class T, class U> std::shared_ptr<T> reinterpret_pointer_cast(const std
 }
 
 //static_pointer_cast overload for std::unique_ptr
-template<class T, class U> std::unique_ptr<T> static_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT
+template<class T, class U> std::unique_ptr<T> static_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) static_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -83,7 +83,7 @@ template<class T, class U> std::unique_ptr<T> static_pointer_cast( std::unique_p
 }
 
 //dynamic_pointer_cast overload for std::unique_ptr
-template<class T, class U> std::unique_ptr<T> dynamic_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT
+template<class T, class U> std::unique_ptr<T> dynamic_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) dynamic_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -95,7 +95,7 @@ template<class T, class U> std::unique_ptr<T> dynamic_pointer_cast( std::unique_
 }
 
 //const_pointer_cast overload for std::unique_ptr
-template<class T, class U> std::unique_ptr<T> const_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT
+template<class T, class U> std::unique_ptr<T> const_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) const_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -105,7 +105,7 @@ template<class T, class U> std::unique_ptr<T> const_pointer_cast( std::unique_pt
 }
 
 //reinterpret_pointer_cast overload for std::unique_ptr
-template<class T, class U> std::unique_ptr<T> reinterpret_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT
+template<class T, class U> std::unique_ptr<T> reinterpret_pointer_cast( std::unique_ptr<U> && r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) reinterpret_cast< T* >( static_cast< U* >( 0 ) );
 

--- a/include/boost/smart_ptr/detail/operator_bool.hpp
+++ b/include/boost/smart_ptr/detail/operator_bool.hpp
@@ -9,14 +9,14 @@
 #if !defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS ) && !defined( BOOST_NO_CXX11_NULLPTR )\
     && !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5130))
 
-    explicit operator bool () const BOOST_NOEXCEPT
+    explicit operator bool () const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px != 0;
     }
 
 #elif ( defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, < 0x570) ) || defined(__CINT__)
 
-    operator bool () const BOOST_NOEXCEPT
+    operator bool () const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px != 0;
     }
@@ -29,7 +29,7 @@
 
     typedef void (*unspecified_bool_type)( this_type*** );
 
-    operator unspecified_bool_type() const BOOST_NOEXCEPT
+    operator unspecified_bool_type() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px == 0? 0: unspecified_bool;
     }
@@ -41,7 +41,7 @@
 
     typedef element_type * (this_type::*unspecified_bool_type)() const;
 
-    operator unspecified_bool_type() const BOOST_NOEXCEPT
+    operator unspecified_bool_type() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px == 0? 0: &this_type::get;
     }
@@ -50,7 +50,7 @@
 
     typedef element_type * this_type::*unspecified_bool_type;
 
-    operator unspecified_bool_type() const BOOST_NOEXCEPT
+    operator unspecified_bool_type() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px == 0? 0: &this_type::px;
     }
@@ -58,7 +58,7 @@
 #endif
 
     // operator! is redundant, but some compilers need it
-    bool operator! () const BOOST_NOEXCEPT
+    bool operator! () const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px == 0;
     }

--- a/include/boost/smart_ptr/detail/sp_forward.hpp
+++ b/include/boost/smart_ptr/detail/sp_forward.hpp
@@ -29,14 +29,14 @@ namespace detail
 
 // GCC 4.4 supports an outdated version of rvalue references and creates a copy of the forwarded object.
 // This results in warnings 'returning reference to temporary'. Therefore we use a special version similar to std::forward.
-template< class T > T&& sp_forward( T && t ) BOOST_NOEXCEPT
+template< class T > T&& sp_forward( T && t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return t;
 }
 
 #else
 
-template< class T > T&& sp_forward( T & t ) BOOST_NOEXCEPT
+template< class T > T&& sp_forward( T & t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return static_cast< T&& >( t );
 }

--- a/include/boost/smart_ptr/enable_shared_from_this.hpp
+++ b/include/boost/smart_ptr/enable_shared_from_this.hpp
@@ -25,20 +25,20 @@ template<class T> class enable_shared_from_this
 {
 protected:
 
-    enable_shared_from_this() BOOST_NOEXCEPT
+    enable_shared_from_this() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
-    enable_shared_from_this(enable_shared_from_this const &) BOOST_NOEXCEPT
+    enable_shared_from_this(enable_shared_from_this const &) BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
-    enable_shared_from_this & operator=(enable_shared_from_this const &) BOOST_NOEXCEPT
+    enable_shared_from_this & operator=(enable_shared_from_this const &) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return *this;
     }
 
-    ~enable_shared_from_this() BOOST_NOEXCEPT // ~weak_ptr<T> newer throws, so this call also must not throw
+    ~enable_shared_from_this() BOOST_NOEXCEPT_OR_NOTHROW // ~weak_ptr<T> newer throws, so this call also must not throw
     {
     }
 
@@ -58,12 +58,12 @@ public:
         return p;
     }
 
-    weak_ptr<T> weak_from_this() BOOST_NOEXCEPT
+    weak_ptr<T> weak_from_this() BOOST_NOEXCEPT_OR_NOTHROW
     {
         return weak_this_;
     }
 
-    weak_ptr<T const> weak_from_this() const BOOST_NOEXCEPT
+    weak_ptr<T const> weak_from_this() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return weak_this_;
     }

--- a/include/boost/smart_ptr/intrusive_ptr.hpp
+++ b/include/boost/smart_ptr/intrusive_ptr.hpp
@@ -59,7 +59,7 @@ public:
 
     typedef T element_type;
 
-    BOOST_CONSTEXPR intrusive_ptr() BOOST_NOEXCEPT : px( 0 )
+    BOOST_CONSTEXPR intrusive_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 )
     {
     }
 
@@ -111,12 +111,12 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    intrusive_ptr(intrusive_ptr && rhs) BOOST_NOEXCEPT : px( rhs.px )
+    intrusive_ptr(intrusive_ptr && rhs) BOOST_NOEXCEPT_OR_NOTHROW : px( rhs.px )
     {
         rhs.px = 0;
     }
 
-    intrusive_ptr & operator=(intrusive_ptr && rhs) BOOST_NOEXCEPT
+    intrusive_ptr & operator=(intrusive_ptr && rhs) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< intrusive_ptr && >( rhs ) ).swap(*this);
         return *this;
@@ -140,7 +140,7 @@ public:
     }
 
     template<class U>
-    intrusive_ptr & operator=(intrusive_ptr<U> && rhs) BOOST_NOEXCEPT
+    intrusive_ptr & operator=(intrusive_ptr<U> && rhs) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< intrusive_ptr<U> && >( rhs ) ).swap(*this);
         return *this;
@@ -160,7 +160,7 @@ public:
         return *this;
     }
 
-    void reset() BOOST_NOEXCEPT
+    void reset() BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type().swap( *this );
     }
@@ -175,12 +175,12 @@ public:
         this_type( rhs, add_ref ).swap( *this );
     }
 
-    T * get() const BOOST_NOEXCEPT
+    T * get() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px;
     }
 
-    T * detach() BOOST_NOEXCEPT
+    T * detach() BOOST_NOEXCEPT_OR_NOTHROW
     {
         T * ret = px;
         px = 0;
@@ -202,7 +202,7 @@ public:
 // implicit conversion to "bool"
 #include <boost/smart_ptr/detail/operator_bool.hpp>
 
-    void swap(intrusive_ptr & rhs) BOOST_NOEXCEPT
+    void swap(intrusive_ptr & rhs) BOOST_NOEXCEPT_OR_NOTHROW
     {
         T * tmp = px;
         px = rhs.px;
@@ -257,22 +257,22 @@ template<class T> inline bool operator!=(intrusive_ptr<T> const & a, intrusive_p
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-template<class T> inline bool operator==( intrusive_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( intrusive_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( boost::detail::sp_nullptr_t, intrusive_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( boost::detail::sp_nullptr_t, intrusive_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( intrusive_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( intrusive_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, intrusive_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, intrusive_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }

--- a/include/boost/smart_ptr/intrusive_ref_counter.hpp
+++ b/include/boost/smart_ptr/intrusive_ref_counter.hpp
@@ -45,17 +45,17 @@ struct thread_unsafe_counter
 {
     typedef unsigned int type;
 
-    static unsigned int load(unsigned int const& counter) BOOST_NOEXCEPT
+    static unsigned int load(unsigned int const& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return counter;
     }
 
-    static void increment(unsigned int& counter) BOOST_NOEXCEPT
+    static void increment(unsigned int& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         ++counter;
     }
 
-    static unsigned int decrement(unsigned int& counter) BOOST_NOEXCEPT
+    static unsigned int decrement(unsigned int& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return --counter;
     }
@@ -71,17 +71,17 @@ struct thread_safe_counter
 {
     typedef boost::detail::atomic_count type;
 
-    static unsigned int load(boost::detail::atomic_count const& counter) BOOST_NOEXCEPT
+    static unsigned int load(boost::detail::atomic_count const& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast< unsigned int >(static_cast< long >(counter));
     }
 
-    static void increment(boost::detail::atomic_count& counter) BOOST_NOEXCEPT
+    static void increment(boost::detail::atomic_count& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         ++counter;
     }
 
-    static unsigned int decrement(boost::detail::atomic_count& counter) BOOST_NOEXCEPT
+    static unsigned int decrement(boost::detail::atomic_count& counter) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast< unsigned int >(--counter);
     }
@@ -91,9 +91,9 @@ template< typename DerivedT, typename CounterPolicyT = thread_safe_counter >
 class intrusive_ref_counter;
 
 template< typename DerivedT, typename CounterPolicyT >
-void intrusive_ptr_add_ref(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT;
+void intrusive_ptr_add_ref(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW;
 template< typename DerivedT, typename CounterPolicyT >
-void intrusive_ptr_release(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT;
+void intrusive_ptr_release(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW;
 
 /*!
  * \brief A reference counter base class
@@ -121,7 +121,7 @@ public:
      *
      * \post <tt>use_count() == 0</tt>
      */
-    intrusive_ref_counter() BOOST_NOEXCEPT : m_ref_counter(0)
+    intrusive_ref_counter() BOOST_NOEXCEPT_OR_NOTHROW : m_ref_counter(0)
     {
     }
 
@@ -130,7 +130,7 @@ public:
      *
      * \post <tt>use_count() == 0</tt>
      */
-    intrusive_ref_counter(intrusive_ref_counter const&) BOOST_NOEXCEPT : m_ref_counter(0)
+    intrusive_ref_counter(intrusive_ref_counter const&) BOOST_NOEXCEPT_OR_NOTHROW : m_ref_counter(0)
     {
     }
 
@@ -139,12 +139,12 @@ public:
      *
      * \post The reference counter is not modified after assignment
      */
-    intrusive_ref_counter& operator= (intrusive_ref_counter const&) BOOST_NOEXCEPT { return *this; }
+    intrusive_ref_counter& operator= (intrusive_ref_counter const&) BOOST_NOEXCEPT_OR_NOTHROW { return *this; }
 
     /*!
      * \return The reference counter
      */
-    unsigned int use_count() const BOOST_NOEXCEPT
+    unsigned int use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return CounterPolicyT::load(m_ref_counter);
     }
@@ -155,18 +155,18 @@ protected:
      */
     BOOST_DEFAULTED_FUNCTION(~intrusive_ref_counter(), {})
 
-    friend void intrusive_ptr_add_ref< DerivedT, CounterPolicyT >(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT;
-    friend void intrusive_ptr_release< DerivedT, CounterPolicyT >(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT;
+    friend void intrusive_ptr_add_ref< DerivedT, CounterPolicyT >(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW;
+    friend void intrusive_ptr_release< DerivedT, CounterPolicyT >(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW;
 };
 
 template< typename DerivedT, typename CounterPolicyT >
-inline void intrusive_ptr_add_ref(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT
+inline void intrusive_ptr_add_ref(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     CounterPolicyT::increment(p->m_ref_counter);
 }
 
 template< typename DerivedT, typename CounterPolicyT >
-inline void intrusive_ptr_release(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT
+inline void intrusive_ptr_release(const intrusive_ref_counter< DerivedT, CounterPolicyT >* p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     if (CounterPolicyT::decrement(p->m_ref_counter) == 0)
         delete static_cast< const DerivedT* >(p);

--- a/include/boost/smart_ptr/make_shared_object.hpp
+++ b/include/boost/smart_ptr/make_shared_object.hpp
@@ -70,16 +70,16 @@ private:
 
 public:
 
-    sp_ms_deleter() BOOST_NOEXCEPT : initialized_( false )
+    sp_ms_deleter() BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
-    template<class A> explicit sp_ms_deleter( A const & ) BOOST_NOEXCEPT : initialized_( false )
+    template<class A> explicit sp_ms_deleter( A const & ) BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
     // optimization: do not copy storage_
-    sp_ms_deleter( sp_ms_deleter const & ) BOOST_NOEXCEPT : initialized_( false )
+    sp_ms_deleter( sp_ms_deleter const & ) BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
@@ -97,12 +97,12 @@ public:
     {
     }
 
-    void * address() BOOST_NOEXCEPT
+    void * address() BOOST_NOEXCEPT_OR_NOTHROW
     {
         return storage_.data_;
     }
 
-    void set_initialized() BOOST_NOEXCEPT
+    void set_initialized() BOOST_NOEXCEPT_OR_NOTHROW
     {
         initialized_ = true;
     }
@@ -142,12 +142,12 @@ private:
 
 public:
 
-    sp_as_deleter( A const & a ) BOOST_NOEXCEPT : a_( a ), initialized_( false )
+    sp_as_deleter( A const & a ) BOOST_NOEXCEPT_OR_NOTHROW : a_( a ), initialized_( false )
     {
     }
 
     // optimization: do not copy storage_
-    sp_as_deleter( sp_as_deleter const & r ) BOOST_NOEXCEPT : a_( r.a_), initialized_( false )
+    sp_as_deleter( sp_as_deleter const & r ) BOOST_NOEXCEPT_OR_NOTHROW : a_( r.a_), initialized_( false )
     {
     }
 
@@ -165,12 +165,12 @@ public:
     {
     }
 
-    void * address() BOOST_NOEXCEPT
+    void * address() BOOST_NOEXCEPT_OR_NOTHROW
     {
         return storage_.data_;
     }
 
-    void set_initialized() BOOST_NOEXCEPT
+    void set_initialized() BOOST_NOEXCEPT_OR_NOTHROW
     {
         initialized_ = true;
     }

--- a/include/boost/smart_ptr/scoped_array.hpp
+++ b/include/boost/smart_ptr/scoped_array.hpp
@@ -54,7 +54,7 @@ public:
 
     typedef T element_type;
 
-    explicit scoped_array( T * p = 0 ) BOOST_NOEXCEPT : px( p )
+    explicit scoped_array( T * p = 0 ) BOOST_NOEXCEPT_OR_NOTHROW : px( p )
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_array_constructor_hook( px );
@@ -69,20 +69,20 @@ public:
         boost::checked_array_delete( px );
     }
 
-    void reset(T * p = 0) // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    void reset(T * p = 0) // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     {
         BOOST_ASSERT( p == 0 || p != px ); // catch self-reset errors
         this_type(p).swap(*this);
     }
 
-    T & operator[](std::ptrdiff_t i) const // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    T & operator[](std::ptrdiff_t i) const // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     {
         BOOST_ASSERT( px != 0 );
         BOOST_ASSERT( i >= 0 );
         return px[i];
     }
 
-    T * get() const BOOST_NOEXCEPT
+    T * get() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px;
     }
@@ -90,7 +90,7 @@ public:
 // implicit conversion to "bool"
 #include <boost/smart_ptr/detail/operator_bool.hpp>
 
-    void swap(scoped_array & b) BOOST_NOEXCEPT
+    void swap(scoped_array & b) BOOST_NOEXCEPT_OR_NOTHROW
     {
         T * tmp = b.px;
         b.px = px;
@@ -100,29 +100,29 @@ public:
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-template<class T> inline bool operator==( scoped_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( scoped_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( boost::detail::sp_nullptr_t, scoped_array<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( boost::detail::sp_nullptr_t, scoped_array<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( scoped_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( scoped_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, scoped_array<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, scoped_array<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
 #endif
 
-template<class T> inline void swap(scoped_array<T> & a, scoped_array<T> & b) BOOST_NOEXCEPT
+template<class T> inline void swap(scoped_array<T> & a, scoped_array<T> & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     a.swap(b);
 }

--- a/include/boost/smart_ptr/scoped_ptr.hpp
+++ b/include/boost/smart_ptr/scoped_ptr.hpp
@@ -71,7 +71,7 @@ public:
 
 #ifndef BOOST_NO_AUTO_PTR
 
-    explicit scoped_ptr( std::auto_ptr<T> p ) BOOST_NOEXCEPT : px( p.release() )
+    explicit scoped_ptr( std::auto_ptr<T> p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p.release() )
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_scalar_constructor_hook( px );
@@ -106,7 +106,7 @@ public:
         return px;
     }
 
-    T * get() const BOOST_NOEXCEPT
+    T * get() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px;
     }
@@ -114,7 +114,7 @@ public:
 // implicit conversion to "bool"
 #include <boost/smart_ptr/detail/operator_bool.hpp>
 
-    void swap(scoped_ptr & b) BOOST_NOEXCEPT
+    void swap(scoped_ptr & b) BOOST_NOEXCEPT_OR_NOTHROW
     {
         T * tmp = b.px;
         b.px = px;
@@ -124,36 +124,36 @@ public:
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-template<class T> inline bool operator==( scoped_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( scoped_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( boost::detail::sp_nullptr_t, scoped_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( boost::detail::sp_nullptr_t, scoped_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( scoped_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( scoped_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, scoped_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, scoped_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
 #endif
 
-template<class T> inline void swap(scoped_ptr<T> & a, scoped_ptr<T> & b) BOOST_NOEXCEPT
+template<class T> inline void swap(scoped_ptr<T> & a, scoped_ptr<T> & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     a.swap(b);
 }
 
 // get_pointer(p) is a generic way to say p.get()
 
-template<class T> inline T * get_pointer(scoped_ptr<T> const & p) BOOST_NOEXCEPT
+template<class T> inline T * get_pointer(scoped_ptr<T> const & p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get();
 }

--- a/include/boost/smart_ptr/shared_array.hpp
+++ b/include/boost/smart_ptr/shared_array.hpp
@@ -53,13 +53,13 @@ public:
 
     typedef T element_type;
 
-    shared_array() BOOST_NOEXCEPT : px( 0 ), pn()
+    shared_array() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn()
     {
     }
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_array( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT : px( 0 ), pn()
+    shared_array( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn()
     {
     }
 
@@ -95,11 +95,11 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    shared_array( shared_array const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    shared_array( shared_array const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
-    shared_array( shared_array && r ) BOOST_NOEXCEPT : px( r.px ), pn()
+    shared_array( shared_array && r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -119,7 +119,7 @@ public:
     shared_array( shared_array<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn ) // never throws
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn ) // never throws
     {
         boost::detail::sp_assert_convertible< Y[], T[] >();
     }
@@ -127,13 +127,13 @@ public:
     // aliasing
 
     template< class Y >
-    shared_array( shared_array<Y> const & r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn( r.pn )
+    shared_array( shared_array<Y> const & r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn( r.pn )
     {
     }
 
     // assignment
 
-    shared_array & operator=( shared_array const & r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( r ).swap( *this );
         return *this;
@@ -142,7 +142,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1400)
 
     template<class Y>
-    shared_array & operator=( shared_array<Y> const & r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( r ).swap( *this );
         return *this;
@@ -152,14 +152,14 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    shared_array & operator=( shared_array && r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_array && >( r ) ).swap( *this );
         return *this;
     }
 
     template<class Y>
-    shared_array & operator=( shared_array<Y> && r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_array<Y> && >( r ) ).swap( *this );
         return *this;
@@ -167,7 +167,7 @@ public:
 
 #endif
 
-    void reset() BOOST_NOEXCEPT
+    void reset() BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type().swap( *this );
     }
@@ -193,14 +193,14 @@ public:
         this_type( r, p ).swap( *this );
     }
 
-    T & operator[] (std::ptrdiff_t i) const // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    T & operator[] (std::ptrdiff_t i) const // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     {
         BOOST_ASSERT(px != 0);
         BOOST_ASSERT(i >= 0);
         return px[i];
     }
     
-    T * get() const BOOST_NOEXCEPT
+    T * get() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px;
     }
@@ -208,17 +208,17 @@ public:
 // implicit conversion to "bool"
 #include <boost/smart_ptr/detail/operator_bool.hpp>
 
-    bool unique() const BOOST_NOEXCEPT
+    bool unique() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.unique();
     }
 
-    long use_count() const BOOST_NOEXCEPT
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.use_count();
     }
 
-    void swap(shared_array<T> & other) BOOST_NOEXCEPT
+    void swap(shared_array<T> & other) BOOST_NOEXCEPT_OR_NOTHROW
     {
         std::swap(px, other.px);
         pn.swap(other.pn);
@@ -238,46 +238,46 @@ private:
 
 };  // shared_array
 
-template<class T> inline bool operator==(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT
+template<class T> inline bool operator==(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.get() == b.get();
 }
 
-template<class T> inline bool operator!=(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT
+template<class T> inline bool operator!=(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.get() != b.get();
 }
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-template<class T> inline bool operator==( shared_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( shared_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( boost::detail::sp_nullptr_t, shared_array<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( boost::detail::sp_nullptr_t, shared_array<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( shared_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( shared_array<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, shared_array<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, shared_array<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
 #endif
 
-template<class T> inline bool operator<(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT
+template<class T> inline bool operator<(shared_array<T> const & a, shared_array<T> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return std::less<T*>()(a.get(), b.get());
 }
 
-template<class T> void swap(shared_array<T> & a, shared_array<T> & b) BOOST_NOEXCEPT
+template<class T> void swap(shared_array<T> & a, shared_array<T> & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     a.swap(b);
 }

--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -344,13 +344,13 @@ public:
 
     typedef typename boost::detail::sp_element< T >::type element_type;
 
-    shared_ptr() BOOST_NOEXCEPT : px( 0 ), pn() // never throws in 1.30+
+    shared_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn() // never throws in 1.30+
     {
     }
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_ptr( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT : px( 0 ), pn() // never throws
+    shared_ptr( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn() // never throws
     {
     }
 
@@ -402,7 +402,7 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    shared_ptr( shared_ptr const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    shared_ptr( shared_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
@@ -419,7 +419,7 @@ public:
 
     template<class Y>
     shared_ptr( weak_ptr<Y> const & r, boost::detail::sp_nothrow_tag )
-    BOOST_NOEXCEPT : px( 0 ), pn( r.pn, boost::detail::sp_nothrow_tag() )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn( r.pn, boost::detail::sp_nothrow_tag() )
     {
         if( !pn.empty() )
         {
@@ -437,14 +437,14 @@ public:
     shared_ptr( shared_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
 
     // aliasing
     template< class Y >
-    shared_ptr( shared_ptr<Y> const & r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn( r.pn )
+    shared_ptr( shared_ptr<Y> const & r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn( r.pn )
     {
     }
 
@@ -521,7 +521,7 @@ public:
 
     // assignment
 
-    shared_ptr & operator=( shared_ptr const & r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type(r).swap(*this);
         return *this;
@@ -530,7 +530,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1400)
 
     template<class Y>
-    shared_ptr & operator=(shared_ptr<Y> const & r) BOOST_NOEXCEPT
+    shared_ptr & operator=(shared_ptr<Y> const & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type(r).swap(*this);
         return *this;
@@ -605,7 +605,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    shared_ptr( shared_ptr && r ) BOOST_NOEXCEPT : px( r.px ), pn()
+    shared_ptr( shared_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -621,7 +621,7 @@ public:
     shared_ptr( shared_ptr<Y> && r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn()
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -629,14 +629,14 @@ public:
         r.px = 0;
     }
 
-    shared_ptr & operator=( shared_ptr && r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_ptr && >( r ) ).swap( *this );
         return *this;
     }
 
     template<class Y>
-    shared_ptr & operator=( shared_ptr<Y> && r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_ptr<Y> && >( r ) ).swap( *this );
         return *this;
@@ -644,7 +644,7 @@ public:
 
     // aliasing move
     template<class Y>
-    shared_ptr( shared_ptr<Y> && r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn()
+    shared_ptr( shared_ptr<Y> && r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -654,7 +654,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_ptr & operator=( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT // never throws
+    shared_ptr & operator=( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW // never throws
     {
         this_type().swap(*this);
         return *this;
@@ -662,7 +662,7 @@ public:
 
 #endif
 
-    void reset() BOOST_NOEXCEPT // never throws in 1.30+
+    void reset() BOOST_NOEXCEPT_OR_NOTHROW // never throws in 1.30+
     {
         this_type().swap(*this);
     }
@@ -697,21 +697,21 @@ public:
 
 #endif
 
-    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     typename boost::detail::sp_dereference< T >::type operator* () const
     {
         BOOST_ASSERT( px != 0 );
         return *px;
     }
     
-    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     typename boost::detail::sp_member_access< T >::type operator-> () const 
     {
         BOOST_ASSERT( px != 0 );
         return px;
     }
     
-    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT)
+    // never throws (but has a BOOST_ASSERT in it, so not marked with BOOST_NOEXCEPT_OR_NOTHROW)
     typename boost::detail::sp_array_access< T >::type operator[] ( std::ptrdiff_t i ) const
     {
         BOOST_ASSERT( px != 0 );
@@ -720,7 +720,7 @@ public:
         return static_cast< typename boost::detail::sp_array_access< T >::type >( px[ i ] );
     }
 
-    element_type * get() const BOOST_NOEXCEPT
+    element_type * get() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px;
     }
@@ -728,43 +728,43 @@ public:
 // implicit conversion to "bool"
 #include <boost/smart_ptr/detail/operator_bool.hpp>
 
-    bool unique() const BOOST_NOEXCEPT
+    bool unique() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.unique();
     }
 
-    long use_count() const BOOST_NOEXCEPT
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.use_count();
     }
 
-    void swap( shared_ptr & other ) BOOST_NOEXCEPT
+    void swap( shared_ptr & other ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         std::swap(px, other.px);
         pn.swap(other.pn);
     }
 
-    template<class Y> bool owner_before( shared_ptr<Y> const & rhs ) const BOOST_NOEXCEPT
+    template<class Y> bool owner_before( shared_ptr<Y> const & rhs ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn < rhs.pn;
     }
 
-    template<class Y> bool owner_before( weak_ptr<Y> const & rhs ) const BOOST_NOEXCEPT
+    template<class Y> bool owner_before( weak_ptr<Y> const & rhs ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn < rhs.pn;
     }
 
-    void * _internal_get_deleter( boost::detail::sp_typeinfo const & ti ) const BOOST_NOEXCEPT
+    void * _internal_get_deleter( boost::detail::sp_typeinfo const & ti ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.get_deleter( ti );
     }
 
-    void * _internal_get_untyped_deleter() const BOOST_NOEXCEPT
+    void * _internal_get_untyped_deleter() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.get_untyped_deleter();
     }
 
-    bool _internal_equiv( shared_ptr const & r ) const BOOST_NOEXCEPT
+    bool _internal_equiv( shared_ptr const & r ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return px == r.px && pn == r.pn;
     }
@@ -787,12 +787,12 @@ private:
 
 };  // shared_ptr
 
-template<class T, class U> inline bool operator==(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT
+template<class T, class U> inline bool operator==(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.get() == b.get();
 }
 
-template<class T, class U> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT
+template<class T, class U> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.get() != b.get();
 }
@@ -801,7 +801,7 @@ template<class T, class U> inline bool operator!=(shared_ptr<T> const & a, share
 
 // Resolve the ambiguity between our op!= and the one in rel_ops
 
-template<class T> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<T> const & b) BOOST_NOEXCEPT
+template<class T> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<T> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.get() != b.get();
 }
@@ -810,39 +810,39 @@ template<class T> inline bool operator!=(shared_ptr<T> const & a, shared_ptr<T> 
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-template<class T> inline bool operator==( shared_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( shared_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( boost::detail::sp_nullptr_t, shared_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator==( boost::detail::sp_nullptr_t, shared_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( shared_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( shared_ptr<T> const & p, boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, shared_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class T> inline bool operator!=( boost::detail::sp_nullptr_t, shared_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get() != 0;
 }
 
 #endif
 
-template<class T, class U> inline bool operator<(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT
+template<class T, class U> inline bool operator<(shared_ptr<T> const & a, shared_ptr<U> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.owner_before( b );
 }
 
-template<class T> inline void swap(shared_ptr<T> & a, shared_ptr<T> & b) BOOST_NOEXCEPT
+template<class T> inline void swap(shared_ptr<T> & a, shared_ptr<T> & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     a.swap(b);
 }
 
-template<class T, class U> shared_ptr<T> static_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT
+template<class T, class U> shared_ptr<T> static_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) static_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -852,7 +852,7 @@ template<class T, class U> shared_ptr<T> static_pointer_cast( shared_ptr<U> cons
     return shared_ptr<T>( r, p );
 }
 
-template<class T, class U> shared_ptr<T> const_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT
+template<class T, class U> shared_ptr<T> const_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) const_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -862,7 +862,7 @@ template<class T, class U> shared_ptr<T> const_pointer_cast( shared_ptr<U> const
     return shared_ptr<T>( r, p );
 }
 
-template<class T, class U> shared_ptr<T> dynamic_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT
+template<class T, class U> shared_ptr<T> dynamic_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) dynamic_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -872,7 +872,7 @@ template<class T, class U> shared_ptr<T> dynamic_pointer_cast( shared_ptr<U> con
     return p? shared_ptr<T>( r, p ): shared_ptr<T>();
 }
 
-template<class T, class U> shared_ptr<T> reinterpret_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT
+template<class T, class U> shared_ptr<T> reinterpret_pointer_cast( shared_ptr<U> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     (void) reinterpret_cast< T* >( static_cast< U* >( 0 ) );
 
@@ -884,7 +884,7 @@ template<class T, class U> shared_ptr<T> reinterpret_pointer_cast( shared_ptr<U>
 
 // get_pointer() enables boost::mem_fn to recognize shared_ptr
 
-template<class T> inline typename shared_ptr<T>::element_type * get_pointer(shared_ptr<T> const & p) BOOST_NOEXCEPT
+template<class T> inline typename shared_ptr<T>::element_type * get_pointer(shared_ptr<T> const & p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return p.get();
 }
@@ -944,7 +944,7 @@ template<class D, class T> D * basic_get_deleter(shared_ptr<T> const & p)
 
 #else
 
-template<class D, class T> D * basic_get_deleter( shared_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class D, class T> D * basic_get_deleter( shared_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return static_cast<D *>( p._internal_get_deleter(BOOST_SP_TYPEID(D)) );
 }
@@ -968,7 +968,7 @@ public:
         deleter_ = deleter;
     }
 
-    template<typename D> D* get_deleter() const BOOST_NOEXCEPT
+    template<typename D> D* get_deleter() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return boost::detail::basic_get_deleter<D>( deleter_ );
     }
@@ -982,7 +982,7 @@ public:
 
 } // namespace detail
 
-template<class D, class T> D * get_deleter( shared_ptr<T> const & p ) BOOST_NOEXCEPT
+template<class D, class T> D * get_deleter( shared_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     D *del = boost::detail::basic_get_deleter<D>(p);
 
@@ -1001,7 +1001,7 @@ template<class D, class T> D * get_deleter( shared_ptr<T> const & p ) BOOST_NOEX
 
 #if !defined(BOOST_SP_NO_ATOMIC_ACCESS)
 
-template<class T> inline bool atomic_is_lock_free( shared_ptr<T> const * /*p*/ ) BOOST_NOEXCEPT
+template<class T> inline bool atomic_is_lock_free( shared_ptr<T> const * /*p*/ ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return false;
 }
@@ -1080,7 +1080,7 @@ template<class T> inline bool atomic_compare_exchange_explicit( shared_ptr<T> * 
 
 template< class T > struct hash;
 
-template< class T > std::size_t hash_value( boost::shared_ptr<T> const & p ) BOOST_NOEXCEPT
+template< class T > std::size_t hash_value( boost::shared_ptr<T> const & p ) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return boost::hash< typename boost::shared_ptr<T>::element_type* >()( p.get() );
 }

--- a/include/boost/smart_ptr/weak_ptr.hpp
+++ b/include/boost/smart_ptr/weak_ptr.hpp
@@ -31,7 +31,7 @@ public:
 
     typedef typename boost::detail::sp_element< T >::type element_type;
 
-    weak_ptr() BOOST_NOEXCEPT : px(0), pn() // never throws in 1.30+
+    weak_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px(0), pn() // never throws in 1.30+
     {
     }
 
@@ -41,11 +41,11 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    weak_ptr( weak_ptr const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    weak_ptr( weak_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
-    weak_ptr & operator=( weak_ptr const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         px = r.px;
         pn = r.pn;
@@ -81,7 +81,7 @@ public:
     weak_ptr( weak_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px(r.lock().get()), pn(r.pn)
+    BOOST_NOEXCEPT_OR_NOTHROW : px(r.lock().get()), pn(r.pn)
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
@@ -98,7 +98,7 @@ public:
     weak_ptr( weak_ptr<Y> && r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.lock().get() ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.lock().get() ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
     {
         boost::detail::sp_assert_convertible< Y, T >();
         r.px = 0;
@@ -106,13 +106,13 @@ public:
 
     // for better efficiency in the T == Y case
     weak_ptr( weak_ptr && r )
-    BOOST_NOEXCEPT : px( r.px ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
     {
         r.px = 0;
     }
 
     // for better efficiency in the T == Y case
-    weak_ptr & operator=( weak_ptr && r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< weak_ptr && >( r ) ).swap( *this );
         return *this;
@@ -131,7 +131,7 @@ public:
     weak_ptr( shared_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
@@ -139,7 +139,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1300)
 
     template<class Y>
-    weak_ptr & operator=( weak_ptr<Y> const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -152,7 +152,7 @@ public:
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
     template<class Y>
-    weak_ptr & operator=( weak_ptr<Y> && r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< weak_ptr<Y> && >( r ) ).swap( *this );
         return *this;
@@ -161,7 +161,7 @@ public:
 #endif
 
     template<class Y>
-    weak_ptr & operator=( shared_ptr<Y> const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( shared_ptr<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -173,17 +173,17 @@ public:
 
 #endif
 
-    shared_ptr<T> lock() const BOOST_NOEXCEPT
+    shared_ptr<T> lock() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return shared_ptr<T>( *this, boost::detail::sp_nothrow_tag() );
     }
 
-    long use_count() const BOOST_NOEXCEPT
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.use_count();
     }
 
-    bool expired() const BOOST_NOEXCEPT
+    bool expired() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn.use_count() == 0;
     }
@@ -193,12 +193,12 @@ public:
         return pn.empty();
     }
 
-    void reset() BOOST_NOEXCEPT // never throws in 1.30+
+    void reset() BOOST_NOEXCEPT_OR_NOTHROW // never throws in 1.30+
     {
         this_type().swap(*this);
     }
 
-    void swap(this_type & other) BOOST_NOEXCEPT
+    void swap(this_type & other) BOOST_NOEXCEPT_OR_NOTHROW
     {
         std::swap(px, other.px);
         pn.swap(other.pn);
@@ -211,12 +211,12 @@ public:
         pn = r.pn;
     }
 
-    template<class Y> bool owner_before( weak_ptr<Y> const & rhs ) const BOOST_NOEXCEPT
+    template<class Y> bool owner_before( weak_ptr<Y> const & rhs ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn < rhs.pn;
     }
 
-    template<class Y> bool owner_before( shared_ptr<Y> const & rhs ) const BOOST_NOEXCEPT
+    template<class Y> bool owner_before( shared_ptr<Y> const & rhs ) const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pn < rhs.pn;
     }
@@ -238,12 +238,12 @@ private:
 
 };  // weak_ptr
 
-template<class T, class U> inline bool operator<(weak_ptr<T> const & a, weak_ptr<U> const & b) BOOST_NOEXCEPT
+template<class T, class U> inline bool operator<(weak_ptr<T> const & a, weak_ptr<U> const & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return a.owner_before( b );
 }
 
-template<class T> void swap(weak_ptr<T> & a, weak_ptr<T> & b) BOOST_NOEXCEPT
+template<class T> void swap(weak_ptr<T> & a, weak_ptr<T> & b) BOOST_NOEXCEPT_OR_NOTHROW
 {
     a.swap(b);
 }


### PR DESCRIPTION
I was wondering why `std::is_nothrow_move_assignable<boost::shared_ptr<T>>::value` was false, and this appears to be the reason.

This is a simple mechanical replacement and hasn't been individually tested, but it seems reasonably safe. (`BOOST_NOEXCEPT_OR_NOTHROW` was added in https://github.com/boostorg/config/commit/50a562867e72af1796f42b905e34116b837b215e).

Given http://www.boost.org/doc/libs/1_62_0/libs/smart_ptr/smart_ptr.htm#Exception-specifications, you might want to reject this, but I thought I'd suggest it just the same, as current behaviour is confusing in VS2013 (which supports most of C++11 and `throw()` but not `noexcept`).