### PR TITLE
Use throw() when noexcept(true) is not available.

### DIFF
--- a/include/boost/smart_ptr/enable_shared_from_this.hpp
+++ b/include/boost/smart_ptr/enable_shared_from_this.hpp
@@ -25,20 +25,20 @@ template<class T> class enable_shared_from_this
 {
 protected:
 
-    enable_shared_from_this() BOOST_NOEXCEPT
+    enable_shared_from_this() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
-    enable_shared_from_this(enable_shared_from_this const &) BOOST_NOEXCEPT
+    enable_shared_from_this(enable_shared_from_this const &) BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
-    enable_shared_from_this & operator=(enable_shared_from_this const &) BOOST_NOEXCEPT
+    enable_shared_from_this & operator=(enable_shared_from_this const &) BOOST_NOEXCEPT_OR_NOTHROW
     {
         return *this;
     }
 
-    ~enable_shared_from_this() BOOST_NOEXCEPT // ~weak_ptr<T> newer throws, so this call also must not throw
+    ~enable_shared_from_this() BOOST_NOEXCEPT_OR_NOTHROW // ~weak_ptr<T> newer throws, so this call also must not throw
     {
     }
 

--- a/include/boost/smart_ptr/intrusive_ptr.hpp
+++ b/include/boost/smart_ptr/intrusive_ptr.hpp
@@ -59,7 +59,7 @@ public:
 
     typedef T element_type;
 
-    BOOST_CONSTEXPR intrusive_ptr() BOOST_NOEXCEPT : px( 0 )
+    BOOST_CONSTEXPR intrusive_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 )
     {
     }
 
@@ -111,12 +111,12 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    intrusive_ptr(intrusive_ptr && rhs) BOOST_NOEXCEPT : px( rhs.px )
+    intrusive_ptr(intrusive_ptr && rhs) BOOST_NOEXCEPT_OR_NOTHROW : px( rhs.px )
     {
         rhs.px = 0;
     }
 
-    intrusive_ptr & operator=(intrusive_ptr && rhs) BOOST_NOEXCEPT
+    intrusive_ptr & operator=(intrusive_ptr && rhs) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< intrusive_ptr && >( rhs ) ).swap(*this);
         return *this;
@@ -140,7 +140,7 @@ public:
     }
 
     template<class U>
-    intrusive_ptr & operator=(intrusive_ptr<U> && rhs) BOOST_NOEXCEPT
+    intrusive_ptr & operator=(intrusive_ptr<U> && rhs) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< intrusive_ptr<U> && >( rhs ) ).swap(*this);
         return *this;

--- a/include/boost/smart_ptr/intrusive_ref_counter.hpp
+++ b/include/boost/smart_ptr/intrusive_ref_counter.hpp
@@ -121,7 +121,7 @@ public:
      *
      * \post <tt>use_count() == 0</tt>
      */
-    intrusive_ref_counter() BOOST_NOEXCEPT : m_ref_counter(0)
+    intrusive_ref_counter() BOOST_NOEXCEPT_OR_NOTHROW : m_ref_counter(0)
     {
     }
 
@@ -130,7 +130,7 @@ public:
      *
      * \post <tt>use_count() == 0</tt>
      */
-    intrusive_ref_counter(intrusive_ref_counter const&) BOOST_NOEXCEPT : m_ref_counter(0)
+    intrusive_ref_counter(intrusive_ref_counter const&) BOOST_NOEXCEPT_OR_NOTHROW : m_ref_counter(0)
     {
     }
 
@@ -139,7 +139,7 @@ public:
      *
      * \post The reference counter is not modified after assignment
      */
-    intrusive_ref_counter& operator= (intrusive_ref_counter const&) BOOST_NOEXCEPT { return *this; }
+    intrusive_ref_counter& operator= (intrusive_ref_counter const&) BOOST_NOEXCEPT_OR_NOTHROW { return *this; }
 
     /*!
      * \return The reference counter

--- a/include/boost/smart_ptr/make_shared_object.hpp
+++ b/include/boost/smart_ptr/make_shared_object.hpp
@@ -70,16 +70,16 @@ private:
 
 public:
 
-    sp_ms_deleter() BOOST_NOEXCEPT : initialized_( false )
+    sp_ms_deleter() BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
-    template<class A> explicit sp_ms_deleter( A const & ) BOOST_NOEXCEPT : initialized_( false )
+    template<class A> explicit sp_ms_deleter( A const & ) BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
     // optimization: do not copy storage_
-    sp_ms_deleter( sp_ms_deleter const & ) BOOST_NOEXCEPT : initialized_( false )
+    sp_ms_deleter( sp_ms_deleter const & ) BOOST_NOEXCEPT_OR_NOTHROW : initialized_( false )
     {
     }
 
@@ -142,12 +142,12 @@ private:
 
 public:
 
-    sp_as_deleter( A const & a ) BOOST_NOEXCEPT : a_( a ), initialized_( false )
+    sp_as_deleter( A const & a ) BOOST_NOEXCEPT_OR_NOTHROW : a_( a ), initialized_( false )
     {
     }
 
     // optimization: do not copy storage_
-    sp_as_deleter( sp_as_deleter const & r ) BOOST_NOEXCEPT : a_( r.a_), initialized_( false )
+    sp_as_deleter( sp_as_deleter const & r ) BOOST_NOEXCEPT_OR_NOTHROW : a_( r.a_), initialized_( false )
     {
     }
 

--- a/include/boost/smart_ptr/scoped_array.hpp
+++ b/include/boost/smart_ptr/scoped_array.hpp
@@ -54,7 +54,7 @@ public:
 
     typedef T element_type;
 
-    explicit scoped_array( T * p = 0 ) BOOST_NOEXCEPT : px( p )
+    explicit scoped_array( T * p = 0 ) BOOST_NOEXCEPT_OR_NOTHROW : px( p )
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_array_constructor_hook( px );

--- a/include/boost/smart_ptr/scoped_ptr.hpp
+++ b/include/boost/smart_ptr/scoped_ptr.hpp
@@ -71,7 +71,7 @@ public:
 
 #ifndef BOOST_NO_AUTO_PTR
 
-    explicit scoped_ptr( std::auto_ptr<T> p ) BOOST_NOEXCEPT : px( p.release() )
+    explicit scoped_ptr( std::auto_ptr<T> p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p.release() )
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_scalar_constructor_hook( px );

--- a/include/boost/smart_ptr/shared_array.hpp
+++ b/include/boost/smart_ptr/shared_array.hpp
@@ -53,13 +53,13 @@ public:
 
     typedef T element_type;
 
-    shared_array() BOOST_NOEXCEPT : px( 0 ), pn()
+    shared_array() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn()
     {
     }
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_array( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT : px( 0 ), pn()
+    shared_array( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn()
     {
     }
 
@@ -95,11 +95,11 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    shared_array( shared_array const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    shared_array( shared_array const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
-    shared_array( shared_array && r ) BOOST_NOEXCEPT : px( r.px ), pn()
+    shared_array( shared_array && r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -119,7 +119,7 @@ public:
     shared_array( shared_array<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn ) // never throws
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn ) // never throws
     {
         boost::detail::sp_assert_convertible< Y[], T[] >();
     }
@@ -127,13 +127,13 @@ public:
     // aliasing
 
     template< class Y >
-    shared_array( shared_array<Y> const & r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn( r.pn )
+    shared_array( shared_array<Y> const & r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn( r.pn )
     {
     }
 
     // assignment
 
-    shared_array & operator=( shared_array const & r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( r ).swap( *this );
         return *this;
@@ -142,7 +142,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1400)
 
     template<class Y>
-    shared_array & operator=( shared_array<Y> const & r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( r ).swap( *this );
         return *this;
@@ -152,14 +152,14 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    shared_array & operator=( shared_array && r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_array && >( r ) ).swap( *this );
         return *this;
     }
 
     template<class Y>
-    shared_array & operator=( shared_array<Y> && r ) BOOST_NOEXCEPT
+    shared_array & operator=( shared_array<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_array<Y> && >( r ) ).swap( *this );
         return *this;

--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -344,13 +344,13 @@ public:
 
     typedef typename boost::detail::sp_element< T >::type element_type;
 
-    shared_ptr() BOOST_NOEXCEPT : px( 0 ), pn() // never throws in 1.30+
+    shared_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn() // never throws in 1.30+
     {
     }
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_ptr( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT : px( 0 ), pn() // never throws
+    shared_ptr( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn() // never throws
     {
     }
 
@@ -402,7 +402,7 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    shared_ptr( shared_ptr const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    shared_ptr( shared_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
@@ -419,7 +419,7 @@ public:
 
     template<class Y>
     shared_ptr( weak_ptr<Y> const & r, boost::detail::sp_nothrow_tag )
-    BOOST_NOEXCEPT : px( 0 ), pn( r.pn, boost::detail::sp_nothrow_tag() )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( 0 ), pn( r.pn, boost::detail::sp_nothrow_tag() )
     {
         if( !pn.empty() )
         {
@@ -437,14 +437,14 @@ public:
     shared_ptr( shared_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
 
     // aliasing
     template< class Y >
-    shared_ptr( shared_ptr<Y> const & r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn( r.pn )
+    shared_ptr( shared_ptr<Y> const & r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn( r.pn )
     {
     }
 
@@ -521,7 +521,7 @@ public:
 
     // assignment
 
-    shared_ptr & operator=( shared_ptr const & r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type(r).swap(*this);
         return *this;
@@ -530,7 +530,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1400)
 
     template<class Y>
-    shared_ptr & operator=(shared_ptr<Y> const & r) BOOST_NOEXCEPT
+    shared_ptr & operator=(shared_ptr<Y> const & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type(r).swap(*this);
         return *this;
@@ -605,7 +605,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    shared_ptr( shared_ptr && r ) BOOST_NOEXCEPT : px( r.px ), pn()
+    shared_ptr( shared_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -621,7 +621,7 @@ public:
     shared_ptr( shared_ptr<Y> && r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn()
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn()
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -629,14 +629,14 @@ public:
         r.px = 0;
     }
 
-    shared_ptr & operator=( shared_ptr && r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_ptr && >( r ) ).swap( *this );
         return *this;
     }
 
     template<class Y>
-    shared_ptr & operator=( shared_ptr<Y> && r ) BOOST_NOEXCEPT
+    shared_ptr & operator=( shared_ptr<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< shared_ptr<Y> && >( r ) ).swap( *this );
         return *this;
@@ -644,7 +644,7 @@ public:
 
     // aliasing move
     template<class Y>
-    shared_ptr( shared_ptr<Y> && r, element_type * p ) BOOST_NOEXCEPT : px( p ), pn()
+    shared_ptr( shared_ptr<Y> && r, element_type * p ) BOOST_NOEXCEPT_OR_NOTHROW : px( p ), pn()
     {
         pn.swap( r.pn );
         r.px = 0;
@@ -654,7 +654,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_NULLPTR )
 
-    shared_ptr & operator=( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT // never throws
+    shared_ptr & operator=( boost::detail::sp_nullptr_t ) BOOST_NOEXCEPT_OR_NOTHROW // never throws
     {
         this_type().swap(*this);
         return *this;

--- a/include/boost/smart_ptr/weak_ptr.hpp
+++ b/include/boost/smart_ptr/weak_ptr.hpp
@@ -31,7 +31,7 @@ public:
 
     typedef typename boost::detail::sp_element< T >::type element_type;
 
-    weak_ptr() BOOST_NOEXCEPT : px(0), pn() // never throws in 1.30+
+    weak_ptr() BOOST_NOEXCEPT_OR_NOTHROW : px(0), pn() // never throws in 1.30+
     {
     }
 
@@ -41,11 +41,11 @@ public:
 
 // ... except in C++0x, move disables the implicit copy
 
-    weak_ptr( weak_ptr const & r ) BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    weak_ptr( weak_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
     }
 
-    weak_ptr & operator=( weak_ptr const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         px = r.px;
         pn = r.pn;
@@ -81,7 +81,7 @@ public:
     weak_ptr( weak_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px(r.lock().get()), pn(r.pn)
+    BOOST_NOEXCEPT_OR_NOTHROW : px(r.lock().get()), pn(r.pn)
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
@@ -98,7 +98,7 @@ public:
     weak_ptr( weak_ptr<Y> && r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.lock().get() ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.lock().get() ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
     {
         boost::detail::sp_assert_convertible< Y, T >();
         r.px = 0;
@@ -106,13 +106,13 @@ public:
 
     // for better efficiency in the T == Y case
     weak_ptr( weak_ptr && r )
-    BOOST_NOEXCEPT : px( r.px ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( static_cast< boost::detail::weak_count && >( r.pn ) )
     {
         r.px = 0;
     }
 
     // for better efficiency in the T == Y case
-    weak_ptr & operator=( weak_ptr && r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< weak_ptr && >( r ) ).swap( *this );
         return *this;
@@ -131,7 +131,7 @@ public:
     weak_ptr( shared_ptr<Y> const & r )
 
 #endif
-    BOOST_NOEXCEPT : px( r.px ), pn( r.pn )
+    BOOST_NOEXCEPT_OR_NOTHROW : px( r.px ), pn( r.pn )
     {
         boost::detail::sp_assert_convertible< Y, T >();
     }
@@ -139,7 +139,7 @@ public:
 #if !defined(BOOST_MSVC) || (BOOST_MSVC >= 1300)
 
     template<class Y>
-    weak_ptr & operator=( weak_ptr<Y> const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         boost::detail::sp_assert_convertible< Y, T >();
 
@@ -152,7 +152,7 @@ public:
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
     template<class Y>
-    weak_ptr & operator=( weak_ptr<Y> && r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( weak_ptr<Y> && r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         this_type( static_cast< weak_ptr<Y> && >( r ) ).swap( *this );
         return *this;
@@ -161,7 +161,7 @@ public:
 #endif
 
     template<class Y>
-    weak_ptr & operator=( shared_ptr<Y> const & r ) BOOST_NOEXCEPT
+    weak_ptr & operator=( shared_ptr<Y> const & r ) BOOST_NOEXCEPT_OR_NOTHROW
     {
         boost::detail::sp_assert_convertible< Y, T >();
 


### PR DESCRIPTION
Only applied to constructors, destructors, and assignment operators, which may
still be detectable via compiler magic when noexcept(expr) is not implemented.

Replacement for PR #27.  (It wouldn't let me reopen that for some reason.)