### PR TITLE
Add rvalue versions of static_pointer_cast, const_pointer_cast, dynamic_pointer_cast, reinterpret_pointer_cast. 

### DIFF
--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -883,6 +883,50 @@ template<class T, class U> shared_ptr<T> reinterpret_pointer_cast( shared_ptr<U>
     return shared_ptr<T>( r, p );
 }
 
+#if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+template<class T, class U> shared_ptr<T> static_pointer_cast( shared_ptr<U> && r ) BOOST_NOEXCEPT
+{
+    (void) static_cast< T* >( static_cast< U* >( 0 ) );
+
+    typedef typename shared_ptr<T>::element_type E;
+
+    E * p = static_cast< E* >( r.get() );
+    return shared_ptr<T>( std::move(r), p );
+}
+
+template<class T, class U> shared_ptr<T> const_pointer_cast( shared_ptr<U> && r ) BOOST_NOEXCEPT
+{
+    (void) const_cast< T* >( static_cast< U* >( 0 ) );
+
+    typedef typename shared_ptr<T>::element_type E;
+
+    E * p = const_cast< E* >( r.get() );
+    return shared_ptr<T>( std::move(r), p );
+}
+
+template<class T, class U> shared_ptr<T> dynamic_pointer_cast( shared_ptr<U> && r ) BOOST_NOEXCEPT
+{
+    (void) dynamic_cast< T* >( static_cast< U* >( 0 ) );
+
+    typedef typename shared_ptr<T>::element_type E;
+
+    E * p = dynamic_cast< E* >( r.get() );
+    return p? shared_ptr<T>( std::move(r), p ): shared_ptr<T>();
+}
+
+template<class T, class U> shared_ptr<T> reinterpret_pointer_cast( shared_ptr<U> && r ) BOOST_NOEXCEPT
+{
+    (void) reinterpret_cast< T* >( static_cast< U* >( 0 ) );
+
+    typedef typename shared_ptr<T>::element_type E;
+
+    E * p = reinterpret_cast< E* >( r.get() );
+    return shared_ptr<T>( std::move(r), p );
+}
+
+#endif // !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
 // get_pointer() enables boost::mem_fn to recognize shared_ptr
 
 template<class T> inline typename shared_ptr<T>::element_type * get_pointer(shared_ptr<T> const & p) BOOST_NOEXCEPT

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -34,6 +34,7 @@ import testing ;
           [ run auto_ptr_rv_test.cpp ]
           [ run shared_ptr_alias_test.cpp ]
           [ run shared_ptr_rv_test.cpp ]
+          [ run shared_ptr_rv_pointer_cast_test.cpp ]
           [ run shared_ptr_move_test.cpp ]
           [ run shared_ptr_alias_move_test.cpp ]
           [ compile-fail shared_ptr_pv_fail.cpp ]

--- a/test/shared_ptr_rv_pointer_cast_test.cpp
+++ b/test/shared_ptr_rv_pointer_cast_test.cpp
@@ -1,0 +1,96 @@
+//
+//  shared_ptr_rv_pointer_cast_test.cpp
+//
+//  Copyright (c) 2016 Chris Glover
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+
+#include <boost/shared_ptr.hpp>
+#include <boost/detail/lightweight_test.hpp>
+
+#if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+struct X
+{};
+
+struct Y: public X
+{};
+
+struct U
+{
+    virtual ~U() {}
+};
+
+struct V: public U
+{};
+
+struct W : public U
+{};
+
+int main()
+{
+    {
+        boost::shared_ptr<X> px(new Y);
+
+        boost::shared_ptr<Y> py1 = boost::static_pointer_cast<Y>(px);
+        boost::shared_ptr<Y> py2 = boost::static_pointer_cast<Y>(std::move(px));
+        BOOST_TEST(!px);
+        BOOST_TEST(px.use_count() == 0);
+        BOOST_TEST(py1.get() == py2.get());
+        BOOST_TEST(!(py1 < py2 || py2 < py1));
+        BOOST_TEST(py1.use_count() == 2);
+        BOOST_TEST(py2.use_count() == 2);
+    }
+
+    {
+        boost::shared_ptr<int const volatile> px(new int);
+
+        boost::shared_ptr<int> px2 = boost::const_pointer_cast<int>(px);
+        boost::shared_ptr<int> px3 = boost::const_pointer_cast<int>(std::move(px));
+        BOOST_TEST(!px);
+        BOOST_TEST(px.use_count() == 0);
+        BOOST_TEST(px2.get() == px3.get());
+        BOOST_TEST(!(px2 < px3 || px2 < px3));
+        BOOST_TEST(px2.use_count() == 2);
+        BOOST_TEST(px3.use_count() == 2);
+    }
+
+#if !defined( BOOST_NO_RTTI )
+    {
+        boost::shared_ptr<U> pu(new V);
+
+        boost::shared_ptr<V> pv1 = boost::dynamic_pointer_cast<V>(pu);
+        boost::shared_ptr<V> pv2 = boost::dynamic_pointer_cast<V>(std::move(pu));
+        BOOST_TEST(!pu);
+        BOOST_TEST(pu.use_count() == 0);
+        BOOST_TEST(pv1.get() == pv2.get());
+        BOOST_TEST(!(pv1 < pv2 || pv2 < pv1));
+        BOOST_TEST(pv1.use_count() == 2);
+        BOOST_TEST(pv2.use_count() == 2);
+    }
+
+    {
+        boost::shared_ptr<U> pu(new V);
+        boost::shared_ptr<W> pw = boost::dynamic_pointer_cast<W>(std::move(pu));
+        BOOST_TEST(!pw);
+        BOOST_TEST(pu);
+    }
+#endif // !defined( BOOST_NO_RTTI )
+
+    return boost::report_errors();
+}
+
+#else // !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+int main()
+{
+    return 0;
+}
+
+
+#endif // !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+

--- a/test/shared_ptr_rv_pointer_cast_test.cpp
+++ b/test/shared_ptr_rv_pointer_cast_test.cpp
@@ -58,6 +58,19 @@ int main()
         BOOST_TEST(px3.use_count() == 2);
     }
 
+    {
+        boost::shared_ptr<char> pv(reinterpret_cast<char*>(new Y));
+
+        boost::shared_ptr<Y> py1 = boost::reinterpret_pointer_cast<Y>(pv);
+        boost::shared_ptr<Y> py2 = boost::reinterpret_pointer_cast<Y>(std::move(pv));
+        BOOST_TEST(!pv);
+        BOOST_TEST(pv.use_count() == 0);
+        BOOST_TEST(py1.get() == py2.get());
+        BOOST_TEST(!(py1 < py2 || py2 < py1));
+        BOOST_TEST(py1.use_count() == 2);
+        BOOST_TEST(py2.use_count() == 2);
+    }
+
 #if !defined( BOOST_NO_RTTI )
     {
         boost::shared_ptr<U> pu(new V);
@@ -90,7 +103,4 @@ int main()
     return 0;
 }
 
-
 #endif // !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
-
-


### PR DESCRIPTION
I came across this today when looking to optimize some code. This saves an atomic increment + decrement on each cast.

Then I discovered there's a similar proposal for std here:
http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0390r0.htm

While I was in there, I noticed that there is no test for reinterpret_pointer_cast. Do we want one?