### PR TITLE
Fix compiling problems under ClangC2.

### DIFF
--- a/include/boost/smart_ptr/detail/sp_counted_base.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base.hpp
@@ -20,7 +20,7 @@
 #include <boost/config.hpp>
 #include <boost/smart_ptr/detail/sp_has_sync.hpp>
 
-#if defined( __clang__ ) && defined( __has_extension )
+#if !defined( __c2__ ) && defined( __clang__ ) && defined( __has_extension )
 # if __has_extension( __c_atomic__ )
 #   define BOOST_SP_HAS_CLANG_C11_ATOMICS
 # endif

--- a/include/boost/smart_ptr/detail/sp_has_sync.hpp
+++ b/include/boost/smart_ptr/detail/sp_has_sync.hpp
@@ -22,7 +22,7 @@
 
 #ifndef BOOST_SP_NO_SYNC
 
-#if defined( __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 )
+#if !defined( __c2__ ) && defined( __GCC_HAVE_SYNC_COMPARE_AND_SWAP_4 )
 
 # define BOOST_SP_HAS_SYNC
 
@@ -30,7 +30,7 @@
 
 # define BOOST_SP_HAS_SYNC
 
-#elif defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
+#elif !defined( __c2__ ) && defined( __GNUC__ ) && ( __GNUC__ * 100 + __GNUC_MINOR__ >= 401 )
 
 #define BOOST_SP_HAS_SYNC
 


### PR DESCRIPTION
Clang/C2 in VS2015 defines __c_atomic__, but can't really use it. Disable __c_atomic__ and BOOST_SP_HAS_SYNC for Clang/C2 to fix 2 compiler internal errors.