### PR TITLE
don't define BOOST_SP_HAS_SYNC for z/OS XL C/C++ compiler

### DIFF
--- a/include/boost/smart_ptr/detail/sp_has_sync.hpp
+++ b/include/boost/smart_ptr/detail/sp_has_sync.hpp
@@ -26,7 +26,7 @@
 
 # define BOOST_SP_HAS_SYNC
 
-#elif defined( __IBMCPP__ ) && ( __IBMCPP__ >= 1210 )
+#elif defined( __IBMCPP__ ) && ( __IBMCPP__ >= 1210 ) && !defined( __COMPILER_VER__ )
 
 # define BOOST_SP_HAS_SYNC
 


### PR DESCRIPTION
The library currently defines BOOST_SP_HAS_SYNC for IBM z/OS XL C/C++, which doesn't support the \_\_sync intrinsics. Adding _&& !defined( \_\_COMPILER\_VER\_\_ )_ to the condition should prevent that.

(According to https://sourceforge.net/p/predef/wiki/Compilers/ _\_\_COMPILER\_VER\_\__ is only defined by IBM z/OS XL C/C++)
