### PR TITLE
Only use allocator construct/destroy for value_type (not shared_count)

### DIFF
--- a/include/boost/smart_ptr/allocate_shared_array.hpp
+++ b/include/boost/smart_ptr/allocate_shared_array.hpp
@@ -352,8 +352,8 @@ sp_array_default(T* storage, std::size_t size)
 template<class T, class U>
 struct sp_less_align {
     enum {
-        value = ((boost::alignment_of<T>::value) <
-            boost::alignment_of<U>::value)
+        value = (boost::alignment_of<T>::value) <
+            (boost::alignment_of<U>::value)
     };
 };
 
@@ -664,7 +664,7 @@ public:
           size_(other.size_),
           result_(other.result_) { }
 
-    value_type* allocate(std::size_t count, const void* = 0) {
+    value_type* allocate(std::size_t count) {
         type_allocator allocator(allocator_);
         std::size_t head = sp_align<value_type, type>(count);
         std::size_t tail = sp_align<T, type>(size_);

--- a/include/boost/smart_ptr/detail/shared_count.hpp
+++ b/include/boost/smart_ptr/detail/shared_count.hpp
@@ -249,18 +249,8 @@ public:
 
         try
         {
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-            impl_type * pi = std::allocator_traits<A2>::allocate( a2, 1 );
-            pi_ = pi;
-            std::allocator_traits<A2>::construct( a2, pi, p, d, a );
-
-#else
-
-            pi_ = a2.allocate( 1, static_cast< impl_type* >( 0 ) );
+            pi_ = a2.allocate( 1 );
             ::new( static_cast< void* >( pi_ ) ) impl_type( p, d, a );
-
-#endif
         }
         catch(...)
         {
@@ -276,28 +266,11 @@ public:
 
 #else
 
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-        impl_type * pi = std::allocator_traits<A2>::allocate( a2, 1 );
-        pi_ = pi;
-
-#else
-
-        pi_ = a2.allocate( 1, static_cast< impl_type* >( 0 ) );
-
-#endif
+        pi_ = a2.allocate( 1 );
 
         if( pi_ != 0 )
         {
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-            std::allocator_traits<A2>::construct( a2, pi, p, d, a );
-
-#else
-
             ::new( static_cast< void* >( pi_ ) ) impl_type( p, d, a );
-
-#endif
         }
         else
         {
@@ -333,18 +306,8 @@ public:
 
         try
         {
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-            impl_type * pi = std::allocator_traits<A2>::allocate( a2, 1 );
-            pi_ = pi;
-            std::allocator_traits<A2>::construct( a2, pi, p, a );
-
-#else
-
-            pi_ = a2.allocate( 1, static_cast< impl_type* >( 0 ) );
+            pi_ = a2.allocate( 1 );
             ::new( static_cast< void* >( pi_ ) ) impl_type( p, a );
-
-#endif
         }
         catch(...)
         {
@@ -360,28 +323,11 @@ public:
 
 #else
 
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-        impl_type * pi = std::allocator_traits<A2>::allocate( a2, 1 );
-        pi_ = pi;
-
-#else
-
-        pi_ = a2.allocate( 1, static_cast< impl_type* >( 0 ) );
-
-#endif
+        pi_ = a2.allocate( 1 );
 
         if( pi_ != 0 )
         {
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-            std::allocator_traits<A2>::construct( a2, pi, p, a );
-
-#else
-
             ::new( static_cast< void* >( pi_ ) ) impl_type( p, a );
-
-#endif
         }
         else
         {

--- a/include/boost/smart_ptr/detail/sp_counted_impl.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_impl.hpp
@@ -236,15 +236,7 @@ public:
 
         A2 a2( a_ );
 
-#if !defined( BOOST_NO_CXX11_ALLOCATOR )
-
-        std::allocator_traits<A2>::destroy( a2, this );
-
-#else
-
         this->~this_type();
-
-#endif
 
         a2.deallocate( this, 1 );
     }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -84,6 +84,7 @@ import testing ;
           [ run sa_nullptr_test.cpp ]
           [ run shared_ptr_alloc3_test.cpp ]
           [ run shared_ptr_alloc11_test.cpp ]
+          [ run shared_ptr_alloc_construct11_test.cpp ]
           [ run allocate_shared_alloc11_test.cpp ]
           [ run allocate_shared_construct11_test.cpp ]
           [ run sp_interlocked_test.cpp ]

--- a/test/shared_ptr_alloc_construct11_test.cpp
+++ b/test/shared_ptr_alloc_construct11_test.cpp
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 Glen Joseph Fernandes
+(glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(http://www.boost.org/LICENSE_1_0.txt)
+*/
+#include <boost/core/lightweight_test.hpp>
+#include <boost/make_shared.hpp>
+
+#if !defined(BOOST_NO_CXX11_ALLOCATOR)
+struct counters {
+    unsigned allocate;
+    unsigned construct;
+};
+
+template<class T>
+class creator {
+public:
+    typedef T value_type;
+
+    creator(counters* state)
+        : state_(state) { }
+
+    template<class U>
+    creator(const creator<U>& other)
+        : state_(other.state()) { }
+
+    T* allocate(std::size_t size) {
+        void* ptr = ::operator new(sizeof(T) * size);
+        ++state_->allocate;
+        return static_cast<T*>(ptr);
+    }
+
+    void deallocate(T* ptr, std::size_t) {
+        ::operator delete(ptr);
+        --state_->allocate;
+    }
+
+    template<class... Args>
+    void construct(T* ptr, Args&&... args) {
+        ::new(static_cast<void*>(ptr)) T(std::forward<Args>(args)...);
+        ++state_->construct;
+    }
+
+    void destroy(T* ptr) {
+        ptr->~T();
+        --state_->construct;
+    }
+
+    counters* state() const {
+        return state_;
+    }
+
+private:
+    counters* state_;
+};
+
+template<class T, class U>
+inline bool
+operator==(const creator<T>& lhs, const creator<U>& rhs)
+{
+    return lhs.state() == rhs.state();
+}
+
+template<class T, class U>
+inline bool
+operator!=(const creator<T>& lhs, const creator<U>& rhs)
+{
+    return !(lhs == rhs);
+}
+
+struct deleter {
+    template<class U>
+    void operator()(U ptr) const {
+        delete ptr;
+    }
+};
+
+int main()
+{
+    {
+        counters state = { };
+        boost::shared_ptr<int> pointer(new int(), deleter(),
+            creator<int>(&state));
+        BOOST_TEST(state.allocate == 1);
+        BOOST_TEST(state.construct == 0);
+        pointer.reset();
+        BOOST_TEST(state.allocate == 0);
+    }
+    {
+        counters state = { };
+        boost::shared_ptr<int> pointer =
+            boost::allocate_shared<int>(creator<int>(&state));
+        BOOST_TEST(state.allocate == 1);
+        BOOST_TEST(state.construct == 1);
+        pointer.reset();
+        BOOST_TEST(state.allocate == 0);
+        BOOST_TEST(state.construct == 0);
+    }
+    {
+        counters state = { };
+        boost::shared_ptr<int[]> pointer =
+            boost::allocate_shared<int[]>(creator<int>(&state), 5);
+        BOOST_TEST(state.allocate == 1);
+        BOOST_TEST(state.construct == 5);
+        pointer.reset();
+        BOOST_TEST(state.allocate == 0);
+        BOOST_TEST(state.construct == 0);
+    }
+    {
+        counters state = { };
+        boost::shared_ptr<int[5]> pointer =
+            boost::allocate_shared<int[5]>(creator<int>(&state));
+        BOOST_TEST(state.allocate == 1);
+        BOOST_TEST(state.construct == 5);
+        pointer.reset();
+        BOOST_TEST(state.allocate == 0);
+        BOOST_TEST(state.construct == 0);
+    }
+    return boost::report_errors();
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif


### PR DESCRIPTION
Since DR 2070 was first posted, the pattern for using allocators for construct and destroy has changed to only use them for the value_type (and placement new for all other node types).

Also only use allocate(n) instead of allocate(n, nullptr) since that former should be sufficient for C++98 and beyond.