### PR TITLE
Protect clang pragmas with BOOST_CLANG macro.

### DIFF
--- a/include/boost/smart_ptr/bad_weak_ptr.hpp
+++ b/include/boost/smart_ptr/bad_weak_ptr.hpp
@@ -36,9 +36,11 @@ namespace boost
 # pragma option push -pc
 #endif
 
+#if defined(BOOST_CLANG)
 #if defined(__clang__)
 # pragma clang diagnostic push
 # pragma clang diagnostic ignored "-Wweak-vtables"
+#endif
 #endif
 
 class bad_weak_ptr: public std::exception
@@ -51,8 +53,10 @@ public:
     }
 };
 
+#if defined(BOOST_CLANG)
 #if defined(__clang__)
 # pragma clang diagnostic pop
+#endif
 #endif
 
 #if defined(__BORLANDC__) && __BORLANDC__ <= 0x564


### PR DESCRIPTION
Building with Intel c++ on Mac generates numerous warnings of this flavor:

In file included from /Users/kbelco/Projects/local/boost/include/boost/smart_ptr/detail/shared_count.hpp(28),
                 from /Users/kbelco/Projects/local/boost/include/boost/smart_ptr/shared_ptr.hpp(28),
                 from /Users/kbelco/Projects/local/boost/include/boost/shared_ptr.hpp(17),
                 from /Users/kbelco/Projects/edr/src/edr/json_spirit_v4.08/json_spirit/json_spirit_value.h(21),
                 from /Users/kbelco/Projects/edr/src/edr/json_spirit_v4.08/json_spirit/json_spirit_writer.h(13),
                 from /Users/kbelco/Projects/edr/src/edr/json_spirit_v4.08/json_spirit/json_spirit_writer.cpp(6):
/Users/kbelco/Projects/local/boost/include/boost/smart_ptr/bad_weak_ptr.hpp(57): warning #161: unrecognized #pragma
  # pragma clang diagnostic pop
           ^
This patch silences the warnings.
