### PR TITLE
Reencoded a few headers that used Windows-1252 with UTF-8.

### DIFF
--- a/include/boost/smart_ptr/detail/atomic_count_gcc.hpp
+++ b/include/boost/smart_ptr/detail/atomic_count_gcc.hpp
@@ -9,7 +9,7 @@
 //  http://gcc.gnu.org/onlinedocs/porting/Thread-safety.html
 //
 //  Copyright (c) 2001, 2002 Peter Dimov and Multi Media Ltd.
-//  Copyright (c) 2002 Lars Gullik Bjønnes <larsbj@lyx.org>
+//  Copyright (c) 2002 Lars Gullik BjÃ¸nnes <larsbj@lyx.org>
 //  Copyright 2003-2005 Peter Dimov
 //
 //  Distributed under the Boost Software License, Version 1.0. (See


### PR DESCRIPTION
Nearly every header in the boost codebase is UTF-8, but here there
are a few headers which are using Windows-1252, which makes it impossible
for some tools to parse those files. This patch just reencodes them
with UTF-8 like the rest of the codebase. I checked that the name of the
author is still correct after this change.

No functional change intended.