### PR TITLE
fix compilation for nvcc+clang

### DIFF
--- a/include/boost/smart_ptr/detail/local_counted_base.hpp
+++ b/include/boost/smart_ptr/detail/local_counted_base.hpp
@@ -60,12 +60,14 @@ public:
 
     void add_ref() BOOST_SP_NOEXCEPT
     {
+#if !defined(__NVCC__)
 #if defined( __has_builtin )
 # if __has_builtin( __builtin_assume )
 
         __builtin_assume( local_use_count_ >= 1 );
 
 # endif
+#endif
 #endif
 
         local_use_count_ = static_cast<count_type>( local_use_count_ + 1 );


### PR DESCRIPTION
nvcc seems to use the host compiler for preprocessing the source for the device and host compilation.
When compiling the host code with the host compiler (clang), `__builtin_assume` is detected correctly and is also available during compilation.
When compiling the device code with nvcc, this builtin function is not provided by nvcc.