### PR TITLE
Fix docs for intrusive_ptr(intrusive_ptr<Y>)

### DIFF
--- a/doc/smart_ptr/intrusive_ptr.adoc
+++ b/doc/smart_ptr/intrusive_ptr.adoc
@@ -155,7 +155,7 @@ template<class Y> intrusive_ptr(intrusive_ptr<Y> const & r);
 [none]
 * {blank}
 +
-Effects:: `if(r.get() != 0) intrusive_ptr_add_ref(r.get());`.
+Effects:: `if(r.get() != 0) intrusive_ptr_add_ref(reinterpret_cast<T*>(r.get()));`.
 Postconditions:: `get() == r.get()`.
 
 ### destructor


### PR DESCRIPTION
decltype(r.get()) is Y* when constructing new intrusive_ptr<T> instance from
intrusive_ptr<Y> r. So, one may think that intrusive_ptr_add_ref(Y*) is called.

It is important that intrusive_ptr_add_ref(T*) and intrusive_ptr_add_ref(Y*)
may have different implementations.

Actual implementation assigns r.get() to member variable T* xp and then calls
intrusive_ptr_add_ref(xp), so we have to explicitly specify that it is
intrusive_ptr_add_ref(T*) what will be actually called.

Signed-off-by: Matwey V. Kornilov <matwey.kornilov@gmail.com>