### PR TITLE
Replaced // nothrow comments with BOOST_NOEXCEPT_OR_NOTHROW

### DIFF
--- a/extras/src/sp_debug_hooks.cpp
+++ b/extras/src/sp_debug_hooks.cpp
@@ -75,7 +75,7 @@ void * operator new(size_t n) throw(bad_alloc)
 
 #if !defined(__BORLANDC__) || (__BORLANDC__ > 0x551)
 
-void * operator new(size_t n, nothrow_t const &) throw()
+void * operator new(size_t n, nothrow_t const &) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return allocate(n, allocated_scalar);
 }
@@ -97,7 +97,7 @@ void * operator new[](size_t n) throw(bad_alloc)
 
 #if !defined(__BORLANDC__) || (__BORLANDC__ > 0x551)
 
-void * operator new[](size_t n, nothrow_t const &) throw()
+void * operator new[](size_t n, nothrow_t const &) BOOST_NOEXCEPT_OR_NOTHROW
 {
     return allocate(n, allocated_array);
 }
@@ -188,7 +188,7 @@ void sp_array_destructor_hook(void * /* p */)
 
 // operator delete
 
-void operator delete(void * p) throw()
+void operator delete(void * p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     if(p == 0) return;
 
@@ -207,14 +207,14 @@ void operator delete(void * p) throw()
 
 #if !defined(__BORLANDC__) || (__BORLANDC__ > 0x551)
 
-void operator delete(void * p, nothrow_t const &) throw()
+void operator delete(void * p, nothrow_t const &) BOOST_NOEXCEPT_OR_NOTHROW
 {
     ::operator delete(p);
 }
 
 #endif
 
-void operator delete[](void * p) throw()
+void operator delete[](void * p) BOOST_NOEXCEPT_OR_NOTHROW
 {
     if(p == 0) return;
 
@@ -233,7 +233,7 @@ void operator delete[](void * p) throw()
 
 #if !defined(__BORLANDC__) || (__BORLANDC__ > 0x551)
 
-void operator delete[](void * p, nothrow_t const &) throw()
+void operator delete[](void * p, nothrow_t const &) BOOST_NOEXCEPT_OR_NOTHROW
 {
     ::operator delete[](p);
 }

--- a/include/boost/smart_ptr/detail/shared_count.hpp
+++ b/include/boost/smart_ptr/detail/shared_count.hpp
@@ -118,14 +118,14 @@ private:
 
 public:
 
-    BOOST_CONSTEXPR shared_count(): pi_(0) // nothrow
+    BOOST_CONSTEXPR shared_count() BOOST_NOEXCEPT_OR_NOTHROW : pi_(0)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(shared_count_id)
 #endif
     {
     }
 
-    BOOST_CONSTEXPR explicit shared_count( sp_counted_base * pi ): pi_( pi ) // nothrow
+    BOOST_CONSTEXPR explicit shared_count( sp_counted_base * pi ) BOOST_NOEXCEPT_OR_NOTHROW : pi_( pi )
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(shared_count_id)
 #endif
@@ -421,7 +421,7 @@ public:
         r.release();
     }
 
-    ~shared_count() // nothrow
+    ~shared_count() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( pi_ != 0 ) pi_->release();
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
@@ -429,7 +429,7 @@ public:
 #endif
     }
 
-    shared_count(shared_count const & r): pi_(r.pi_) // nothrow
+    shared_count(shared_count const & r) BOOST_NOEXCEPT_OR_NOTHROW : pi_(r.pi_)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(shared_count_id)
 #endif
@@ -439,7 +439,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    shared_count(shared_count && r): pi_(r.pi_) // nothrow
+    shared_count(shared_count && r) BOOST_NOEXCEPT_OR_NOTHROW : pi_(r.pi_)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(shared_count_id)
 #endif
@@ -452,7 +452,7 @@ public:
     explicit shared_count(weak_count const & r); // throws bad_weak_ptr when r.use_count() == 0
     shared_count( weak_count const & r, sp_nothrow_tag ); // constructs an empty *this when r.use_count() == 0
 
-    shared_count & operator= (shared_count const & r) // nothrow
+    shared_count & operator= (shared_count const & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         sp_counted_base * tmp = r.pi_;
 
@@ -466,24 +466,24 @@ public:
         return *this;
     }
 
-    void swap(shared_count & r) // nothrow
+    void swap(shared_count & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         sp_counted_base * tmp = r.pi_;
         r.pi_ = pi_;
         pi_ = tmp;
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pi_ != 0? pi_->use_count(): 0;
     }
 
-    bool unique() const // nothrow
+    bool unique() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return use_count() == 1;
     }
 
-    bool empty() const // nothrow
+    bool empty() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pi_ == 0;
     }
@@ -529,14 +529,14 @@ private:
 
 public:
 
-    BOOST_CONSTEXPR weak_count(): pi_(0) // nothrow
+    BOOST_CONSTEXPR weak_count() BOOST_NOEXCEPT_OR_NOTHROW : pi_(0)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(weak_count_id)
 #endif
     {
     }
 
-    weak_count(shared_count const & r): pi_(r.pi_) // nothrow
+    weak_count(shared_count const & r) BOOST_NOEXCEPT_OR_NOTHROW : pi_(r.pi_)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(weak_count_id)
 #endif
@@ -544,7 +544,7 @@ public:
         if(pi_ != 0) pi_->weak_add_ref();
     }
 
-    weak_count(weak_count const & r): pi_(r.pi_) // nothrow
+    weak_count(weak_count const & r) BOOST_NOEXCEPT_OR_NOTHROW : pi_(r.pi_)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(weak_count_id)
 #endif
@@ -556,7 +556,7 @@ public:
 
 #if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
 
-    weak_count(weak_count && r): pi_(r.pi_) // nothrow
+    weak_count(weak_count && r) BOOST_NOEXCEPT_OR_NOTHROW : pi_(r.pi_)
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         , id_(weak_count_id)
 #endif
@@ -566,7 +566,7 @@ public:
 
 #endif
 
-    ~weak_count() // nothrow
+    ~weak_count() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if(pi_ != 0) pi_->weak_release();
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
@@ -574,7 +574,7 @@ public:
 #endif
     }
 
-    weak_count & operator= (shared_count const & r) // nothrow
+    weak_count & operator= (shared_count const & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         sp_counted_base * tmp = r.pi_;
 
@@ -588,7 +588,7 @@ public:
         return *this;
     }
 
-    weak_count & operator= (weak_count const & r) // nothrow
+    weak_count & operator= (weak_count const & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         sp_counted_base * tmp = r.pi_;
 
@@ -602,19 +602,19 @@ public:
         return *this;
     }
 
-    void swap(weak_count & r) // nothrow
+    void swap(weak_count & r) BOOST_NOEXCEPT_OR_NOTHROW
     {
         sp_counted_base * tmp = r.pi_;
         r.pi_ = pi_;
         pi_ = tmp;
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pi_ != 0? pi_->use_count(): 0;
     }
 
-    bool empty() const // nothrow
+    bool empty() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return pi_ == 0;
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_acc_ia64.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_acc_ia64.hpp
@@ -88,18 +88,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -118,7 +118,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -127,12 +127,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ ); // TODO use ld.acq here
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_aix.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_aix.hpp
@@ -80,18 +80,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -110,7 +110,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -119,12 +119,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -132,7 +132,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return fetch_and_add( const_cast<int32_t*>(&use_count_), 0 );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_clang.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_clang.hpp
@@ -82,18 +82,18 @@ public:
         __c11_atomic_init( &weak_count_, 1 );
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -112,7 +112,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 1 )
         {
@@ -121,12 +121,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 1 )
         {
@@ -134,7 +134,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return __c11_atomic_load( const_cast< atomic_int_least32_t* >( &use_count_ ), __ATOMIC_ACQUIRE );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -108,18 +108,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -138,7 +138,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -147,12 +147,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -160,7 +160,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<long const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_x86.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_x86.hpp
@@ -96,18 +96,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -126,7 +126,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &use_count_, -1 ) == 1 )
         {
@@ -135,12 +135,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &weak_count_, -1 ) == 1 )
         {
@@ -148,7 +148,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_ia64.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_ia64.hpp
@@ -95,18 +95,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -125,7 +125,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -134,12 +134,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -147,7 +147,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ ); // TODO use ld.acq here
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_mips.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_mips.hpp
@@ -125,18 +125,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -155,7 +155,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -164,12 +164,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -177,7 +177,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_ppc.hpp
@@ -119,18 +119,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -149,7 +149,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -158,12 +158,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -171,7 +171,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_sparc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_sparc.hpp
@@ -104,18 +104,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -134,7 +134,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 1 )
         {
@@ -143,12 +143,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 1 )
         {
@@ -156,7 +156,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return const_cast< int32_t const volatile & >( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_gcc_x86.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_gcc_x86.hpp
@@ -111,18 +111,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -141,7 +141,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &use_count_, -1 ) == 1 )
         {
@@ -150,12 +150,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &weak_count_, -1 ) == 1 )
         {
@@ -163,7 +163,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<int const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_nt.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_nt.hpp
@@ -44,18 +44,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -76,7 +76,7 @@ public:
         return true;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( --use_count_ == 0 )
         {
@@ -85,12 +85,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         ++weak_count_;
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( --weak_count_ == 0 )
         {
@@ -98,7 +98,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return use_count_;
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_pt.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_pt.hpp
@@ -55,7 +55,7 @@ public:
 #endif
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_VERIFY( pthread_mutex_destroy( &m_ ) == 0 );
     }
@@ -63,11 +63,11 @@ public:
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -91,7 +91,7 @@ public:
         return r;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_VERIFY( pthread_mutex_lock( &m_ ) == 0 );
         boost::int_least32_t new_use_count = --use_count_;
@@ -104,14 +104,14 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_VERIFY( pthread_mutex_lock( &m_ ) == 0 );
         ++weak_count_;
         BOOST_VERIFY( pthread_mutex_unlock( &m_ ) == 0 );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_VERIFY( pthread_mutex_lock( &m_ ) == 0 );
         boost::int_least32_t new_weak_count = --weak_count_;
@@ -123,7 +123,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_VERIFY( pthread_mutex_lock( &m_ ) == 0 );
         boost::int_least32_t r = use_count_;

--- a/include/boost/smart_ptr/detail/sp_counted_base_snc_ps3.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_snc_ps3.hpp
@@ -99,18 +99,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -129,7 +129,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 1 )
         {
@@ -138,12 +138,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 1 )
         {
@@ -151,7 +151,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return const_cast< uint32_t const volatile & >( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_solaris.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_solaris.hpp
@@ -46,18 +46,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -81,7 +81,7 @@ public:
         }
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_dec_32_nv( &use_count_ ) == 0 )
         {
@@ -90,12 +90,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_inc_32( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_dec_32_nv( &weak_count_ ) == 0 )
         {
@@ -103,7 +103,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<long const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_spin.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_spin.hpp
@@ -68,18 +68,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -98,7 +98,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &use_count_, -1 ) == 1 )
         {
@@ -107,12 +107,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_exchange_and_add( &weak_count_, -1 ) == 1 )
         {
@@ -120,7 +120,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         spinlock_pool<1>::scoped_lock lock( &use_count_ );
         return use_count_;

--- a/include/boost/smart_ptr/detail/sp_counted_base_std_atomic.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_std_atomic.hpp
@@ -74,18 +74,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -104,7 +104,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 1 )
         {
@@ -113,12 +113,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 1 )
         {
@@ -126,7 +126,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return use_count_.load( std::memory_order_acquire );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_sync.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_sync.hpp
@@ -93,18 +93,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -123,7 +123,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 1 )
         {
@@ -132,12 +132,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 1 )
         {
@@ -145,7 +145,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return const_cast< sp_int32_t const volatile & >( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_vacpp_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_vacpp_ppc.hpp
@@ -88,18 +88,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -118,7 +118,7 @@ public:
         return atomic_conditional_increment( &use_count_ ) != 0;
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &use_count_ ) == 0 )
         {
@@ -127,12 +127,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         atomic_increment( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( atomic_decrement( &weak_count_ ) == 0 )
         {
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return *const_cast<volatile int*>(&use_count_); 
     }

--- a/include/boost/smart_ptr/detail/sp_counted_base_w32.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_w32.hpp
@@ -51,18 +51,18 @@ public:
     {
     }
 
-    virtual ~sp_counted_base() // nothrow
+    virtual ~sp_counted_base() BOOST_NOEXCEPT_OR_NOTHROW
     {
     }
 
     // dispose() is called when use_count_ drops to zero, to release
     // the resources managed by *this.
 
-    virtual void dispose() = 0; // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW = 0;
 
     // destroy() is called when weak_count_ drops to zero.
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
         delete this;
     }
@@ -98,7 +98,7 @@ public:
         }
     }
 
-    void release() // nothrow
+    void release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( BOOST_SP_INTERLOCKED_DECREMENT( &use_count_ ) == 0 )
         {
@@ -107,12 +107,12 @@ public:
         }
     }
 
-    void weak_add_ref() // nothrow
+    void weak_add_ref() BOOST_NOEXCEPT_OR_NOTHROW
     {
         BOOST_SP_INTERLOCKED_INCREMENT( &weak_count_ );
     }
 
-    void weak_release() // nothrow
+    void weak_release() BOOST_NOEXCEPT_OR_NOTHROW
     {
         if( BOOST_SP_INTERLOCKED_DECREMENT( &weak_count_ ) == 0 )
         {
@@ -120,7 +120,7 @@ public:
         }
     }
 
-    long use_count() const // nothrow
+    long use_count() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         return static_cast<long const volatile &>( use_count_ );
     }

--- a/include/boost/smart_ptr/detail/sp_counted_impl.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_impl.hpp
@@ -84,7 +84,7 @@ public:
 #endif
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW
     {
 #if defined(BOOST_SP_ENABLE_DEBUG_HOOKS)
         boost::sp_scalar_destructor_hook( px_, sizeof(X), this );
@@ -167,7 +167,7 @@ public:
     {
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW
     {
         del( ptr );
     }
@@ -241,12 +241,12 @@ public:
     {
     }
 
-    virtual void dispose() // nothrow
+    virtual void dispose() BOOST_NOEXCEPT_OR_NOTHROW
     {
         d_( p_ );
     }
 
-    virtual void destroy() // nothrow
+    virtual void destroy() BOOST_NOEXCEPT_OR_NOTHROW
     {
 #if !defined( BOOST_NO_CXX11_ALLOCATOR )
 


### PR DESCRIPTION
rvalue-constructors triggered a warning "C26439 SPECIAL_NOEXCEPT" if code analysis was set to level "Microsoft Native Recommended Rules" when compiling with Visual Studio 2017. See https://docs.microsoft.com/en-us/visualstudio/code-quality/c26439?view=vs-2017

Also, it is better to use language constructs to represent semantics when possible. E.g. it is now possible to store objects of the affected classes in a vector and the vector no longer has to call the copy constructors when resizing its internal buffer. Not sure how relevant it is for these particular objects though.

This resolves issue #63 