### PR TITLE
atomic_count_std_atomic: static_cast v to std::int_least32_t

### DIFF
--- a/include/boost/smart_ptr/detail/atomic_count_std_atomic.hpp
+++ b/include/boost/smart_ptr/detail/atomic_count_std_atomic.hpp
@@ -26,7 +26,7 @@ class atomic_count
 {
 public:
 
-    explicit atomic_count( long v ): value_( v )
+    explicit atomic_count( long v ): value_( static_cast< std::int_least32_t >( v ) )
     {
     }
 


### PR DESCRIPTION
* fix implicit conversion warning