### PR TITLE
Add missing sp_typeinfo_.hpp includes

### DIFF
--- a/include/boost/smart_ptr/allocate_shared_array.hpp
+++ b/include/boost/smart_ptr/allocate_shared_array.hpp
@@ -11,6 +11,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include <boost/core/alloc_construct.hpp>
 #include <boost/core/first_scalar.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/smart_ptr/detail/sp_typeinfo_.hpp>
 #include <boost/type_traits/alignment_of.hpp>
 #include <boost/type_traits/enable_if.hpp>
 #include <boost/type_traits/extent.hpp>

--- a/include/boost/smart_ptr/detail/shared_count.hpp
+++ b/include/boost/smart_ptr/detail/shared_count.hpp
@@ -30,6 +30,7 @@
 #include <boost/smart_ptr/detail/sp_counted_impl.hpp>
 #include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
+#include <boost/smart_ptr/detail/sp_typeinfo_.hpp>
 #include <boost/config/workaround.hpp>
 // In order to avoid circular dependencies with Boost.TR1
 // we make sure that our include of <memory> doesn't try to

--- a/include/boost/smart_ptr/detail/sp_counted_impl.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_impl.hpp
@@ -27,6 +27,7 @@
 #include <boost/checked_delete.hpp>
 #include <boost/smart_ptr/detail/sp_counted_base.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
+#include <boost/smart_ptr/detail/sp_typeinfo_.hpp>
 #include <boost/core/addressof.hpp>
 
 #if defined(BOOST_SP_USE_QUICK_ALLOCATOR)

--- a/include/boost/smart_ptr/shared_array.hpp
+++ b/include/boost/smart_ptr/shared_array.hpp
@@ -25,6 +25,7 @@
 #include <boost/smart_ptr/detail/shared_count.hpp>
 #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
+#include <boost/smart_ptr/detail/sp_typeinfo_.hpp>
 #include <boost/detail/workaround.hpp>
 
 #include <cstddef>            // for std::ptrdiff_t

--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -31,6 +31,7 @@
 #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
 #include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
+#include <boost/smart_ptr/detail/sp_typeinfo_.hpp>
 
 #if !defined(BOOST_SP_NO_ATOMIC_ACCESS)
 #include <boost/smart_ptr/detail/spinlock_pool.hpp>


### PR DESCRIPTION
Some of these are included indirectly, but others are not.
Broken in commit e306b30dcf0.