### PR TITLE
refactor: use boost/core/checked_delete.hpp over boost/checked_delete.hpp

### DIFF
--- a/include/boost/smart_ptr/detail/shared_count.hpp
+++ b/include/boost/smart_ptr/detail/shared_count.hpp
@@ -27,7 +27,7 @@
 #include <boost/smart_ptr/detail/sp_counted_impl.hpp>
 #include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/core/addressof.hpp>
 #include <boost/config.hpp>

--- a/include/boost/smart_ptr/detail/sp_counted_impl.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_impl.hpp
@@ -24,7 +24,7 @@
 
 #include <boost/smart_ptr/detail/sp_counted_base.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/core/addressof.hpp>
 #include <boost/config.hpp>
 

--- a/include/boost/smart_ptr/scoped_array.hpp
+++ b/include/boost/smart_ptr/scoped_array.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
 

--- a/include/boost/smart_ptr/scoped_ptr.hpp
+++ b/include/boost/smart_ptr/scoped_ptr.hpp
@@ -12,7 +12,7 @@
 
 #include <boost/config.hpp>
 #include <boost/assert.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
 #include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>

--- a/include/boost/smart_ptr/shared_array.hpp
+++ b/include/boost/smart_ptr/shared_array.hpp
@@ -19,7 +19,7 @@
 #include <memory>             // TR1 cyclic inclusion fix
 
 #include <boost/assert.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 
 #include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/smart_ptr/detail/shared_count.hpp>

--- a/include/boost/smart_ptr/shared_ptr.hpp
+++ b/include/boost/smart_ptr/shared_ptr.hpp
@@ -19,7 +19,7 @@
 #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
 #include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
-#include <boost/checked_delete.hpp>
+#include <boost/core/checked_delete.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>


### PR DESCRIPTION
boost/checked_delete.hpp has been deprecated:
```cpp
#ifndef BOOST_CHECKED_DELETE_HPP
#define BOOST_CHECKED_DELETE_HPP

// The header file at this path is deprecated;
// use boost/core/checked_delete.hpp instead.

#include <boost/core/checked_delete.hpp>

#endif
```