### PR TITLE
Add support for different sync instructions for CodeWarrior PPC

### DIFF
--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -35,8 +35,6 @@ BOOST_PRAGMA_MESSAGE("Using CodeWarrior/PowerPC sp_counted_base")
 
 #endif
 
-BOOST_SP_OBSOLETE()
-
 namespace boost
 {
 

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -63,11 +63,7 @@ inline long atomic_decrement( register long * pw )
     asm
     {
 #if defined(__PPCZen__) || defined(__PPCe500__) || defined(__PPCe500v2__)
-# if VLE_ON
-    se_isync
-# else
     msync
-# endif
 #else
     sync
 #endif

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -60,10 +60,14 @@ inline long atomic_decrement( register long * pw )
 {
     register int a;
 
-    __sync();
-
     asm
     {
+#if defined(__PPCZen__) || defined(__PPCe500__) || defined(__PPCe500v2__)
+    msync
+#else
+    sync
+#endif
+
 loop:
 
     lwarx   a, 0, pw

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -60,14 +60,10 @@ inline long atomic_decrement( register long * pw )
 {
     register int a;
 
+    __sync();
+
     asm
     {
-#if defined(__PPCZen__) || defined(__PPCe500__) || defined(__PPCe500v2__)
-    msync
-#else
-    sync
-#endif
-
 loop:
 
     lwarx   a, 0, pw

--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -64,7 +64,15 @@ inline long atomic_decrement( register long * pw )
 
     asm
     {
+#if defined(__PPCZen__) || defined(__PPCe500__) || defined(__PPCe500v2__)
+# if VLE_ON
+    se_isync
+# else
+    msync
+# endif
+#else
     sync
+#endif
 
 loop:
 


### PR DESCRIPTION
Un-obsoletes `sp_counted_base_cw_ppc.hpp` as well.

Fixes #94.