### PR TITLE
Remove deprecated register storage specifier

### DIFF
--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -43,7 +43,7 @@ namespace detail
 
 inline void atomic_increment( register long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {
@@ -58,7 +58,7 @@ loop:
 
 inline long atomic_decrement( register long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {
@@ -83,7 +83,7 @@ loop:
 
 inline long atomic_conditional_increment( register long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {


### PR DESCRIPTION
Deprecated as of C++11 and removed in C++17.