### PR TITLE
Add missing ifdef check.

### DIFF
--- a/include/boost/smart_ptr/intrusive_ptr.hpp
+++ b/include/boost/smart_ptr/intrusive_ptr.hpp
@@ -245,7 +245,7 @@ template<class T, class U> inline bool operator!=(T * a, intrusive_ptr<U> const 
     return a != b.get();
 }
 
-#if __GNUC__ == 2 && __GNUC_MINOR__ <= 96
+#if defined(__GNUC__) && __GNUC__ == 2 && __GNUC_MINOR__ <= 96
 
 // Resolve the ambiguity between our op!= and the one in rel_ops
 


### PR DESCRIPTION
Unreal Engine 5 gives following error.
```
boost\smart_ptr\intrusive_ptr.hpp(248): error C4668: 'GNUC' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
```
