### PR TITLE
Remove deprecated register

### DIFF
--- a/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
+++ b/include/boost/smart_ptr/detail/sp_counted_base_cw_ppc.hpp
@@ -41,9 +41,9 @@ namespace boost
 namespace detail
 {
 
-inline void atomic_increment( register long * pw )
+inline void atomic_increment( long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {
@@ -56,9 +56,9 @@ loop:
     }
 }
 
-inline long atomic_decrement( register long * pw )
+inline long atomic_decrement( long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {
@@ -81,9 +81,9 @@ loop:
     return a;
 }
 
-inline long atomic_conditional_increment( register long * pw )
+inline long atomic_conditional_increment( long * pw )
 {
-    register int a;
+    int a;
 
     asm
     {


### PR DESCRIPTION
No longer available in C++ 17, it is time we remove this keyword, including from the function signature itself.