### PR TITLE
Don't define BOOST_SP_HAS_GCC_INTRINSICS for MSVC

### DIFF
--- a/include/boost/smart_ptr/detail/sp_has_gcc_intrinsics.hpp
+++ b/include/boost/smart_ptr/detail/sp_has_gcc_intrinsics.hpp
@@ -18,7 +18,7 @@
 // intrinsics are available.
 
 
-#if defined( __ATOMIC_RELAXED ) && defined( __ATOMIC_ACQUIRE ) && defined( __ATOMIC_RELEASE ) && defined( __ATOMIC_ACQ_REL )
+#if defined( __ATOMIC_RELAXED ) && defined( __ATOMIC_ACQUIRE ) && defined( __ATOMIC_RELEASE ) && defined( __ATOMIC_ACQ_REL ) && !defined(_MSC_VER)
 
 # define BOOST_SP_HAS_GCC_INTRINSICS
 


### PR DESCRIPTION
Mirroring [dealii/dealii@`e969195` (#16621)](https://github.com/dealii/dealii/pull/16621/commits/e969195f058cfa491dad3580797b1190224ef4b9). We were running into errors like
```
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/sp_counted_base_gcc_atomic.hpp(35,5): error C3861: '__atomic_fetch_add': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/sp_counted_base_gcc_atomic.hpp(40,12): error C3861: '__atomic_fetch_sub': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/sp_counted_base_gcc_atomic.hpp(49,31): error C3861: '__atomic_load_n': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/sp_counted_base_gcc_atomic.hpp(58,13): error C3861: '__atomic_compare_exchange_n': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/sp_counted_base_gcc_atomic.hpp(67,12): error C3861: '__atomic_load_n': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/spinlock_gcc_atomic.hpp(48,16): error C3861: '__atomic_test_and_set': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
D:\a\dealii\dealii\bundled\boost-1.84.0\include\boost/smart_ptr/detail/spinlock_gcc_atomic.hpp(61,9): error C3861: '__atomic_clear': identifier not found [D:\a\dealii\dealii\build\source\numerics\object_numerics_debug.vcxproj]
```
with MSVC, see https://github.com/dealii/dealii/pull/16621#issuecomment-1937412229 and https://github.com/dealii/dealii/issues/16413#issue-2065856458. It seems the compiler doesn't support `__atomic_*` intrinsics. 