### PR TITLE
Enable C++20 constexpr for intrusive_ptr

### DIFF
--- a/include/boost/smart_ptr/detail/sp_cxx20_constexpr.hpp
+++ b/include/boost/smart_ptr/detail/sp_cxx20_constexpr.hpp
@@ -1,0 +1,37 @@
+#ifndef BOOST_SMART_PTR_DETAIL_SP_CXX20_CONSTEXPR_HPP_INCLUDED
+#define BOOST_SMART_PTR_DETAIL_SP_CXX20_CONSTEXPR_HPP_INCLUDED
+
+// MS compatible compilers support #pragma once
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+#pragma once
+#endif
+
+//  detail/sp_noexcept.hpp
+//
+//  Copyright 2025 Mathias Stearn
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+
+
+// This macro is used to mark functions as constexpr if the compiler supports
+// constexpr destructors. Since you can't have a constexpr smart pointer object,
+// everything except null constructors are guided behind this macro. Because
+// this also guards a use of dynamic_cast, we need to check for its availability
+// as well. It isn't worth splitting out since all known compilers that support
+// constexpr dynamic_cast also support constexpr destructors.
+//
+// WARNING: This does not check for changing active member of a union in
+// constant expressions which is allowed in C++20. If that is needed, we
+// need to raise the checked version to 202002L.
+#if defined(__cpp_constexpr_dynamic_alloc) && __cpp_constexpr_dynamic_alloc >= 201907L \
+    && defined(__cpp_constexpr) && __cpp_constexpr >= 201907L
+#define BOOST_SP_CXX20_CONSTEXPR constexpr
+#else
+#define BOOST_SP_CXX20_CONSTEXPR
+#define BOOST_SP_NO_CXX20_CONSTEXPR
+#endif
+
+#endif // #ifndef BOOST_SMART_PTR_DETAIL_SP_CXX20_CONSTEXPR_HPP_INCLUDED

--- a/include/boost/smart_ptr/intrusive_ptr.hpp
+++ b/include/boost/smart_ptr/intrusive_ptr.hpp
@@ -13,6 +13,7 @@
 //  See http://www.boost.org/libs/smart_ptr/ for documentation.
 //
 
+#include <boost/smart_ptr/detail/sp_cxx20_constexpr.hpp>
 #include <boost/smart_ptr/detail/sp_convertible.hpp>
 #include <boost/smart_ptr/detail/sp_noexcept.hpp>
 #include <boost/assert.hpp>
@@ -53,29 +54,29 @@ public:
     {
     }
 
-    intrusive_ptr( T * p, bool add_ref = true ): px( p )
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr( T * p, bool add_ref = true ): px( p )
     {
         if( px != 0 && add_ref ) intrusive_ptr_add_ref( px );
     }
 
     template<class U>
-    intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertible<U,T>::type = boost::detail::sp_empty() )
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertible<U,T>::type = boost::detail::sp_empty() )
     : px( rhs.get() )
     {
         if( px != 0 ) intrusive_ptr_add_ref( px );
     }
 
-    intrusive_ptr(intrusive_ptr const & rhs): px( rhs.px )
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr const & rhs): px( rhs.px )
     {
         if( px != 0 ) intrusive_ptr_add_ref( px );
     }
 
-    ~intrusive_ptr()
+    BOOST_SP_CXX20_CONSTEXPR ~intrusive_ptr()
     {
         if( px != 0 ) intrusive_ptr_release( px );
     }
 
-    template<class U> intrusive_ptr & operator=(intrusive_ptr<U> const & rhs)
+    template<class U> BOOST_SP_CXX20_CONSTEXPR intrusive_ptr & operator=(intrusive_ptr<U> const & rhs)
     {
         this_type(rhs).swap(*this);
         return *this;
@@ -83,12 +84,12 @@ public:
 
 // Move support
 
-    intrusive_ptr(intrusive_ptr && rhs) noexcept : px( rhs.px )
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr && rhs) noexcept : px( rhs.px )
     {
         rhs.px = 0;
     }
 
-    intrusive_ptr & operator=(intrusive_ptr && rhs) noexcept
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr & operator=(intrusive_ptr && rhs) noexcept
     {
         this_type( static_cast< intrusive_ptr && >( rhs ) ).swap(*this);
         return *this;
@@ -97,76 +98,76 @@ public:
     template<class U> friend class intrusive_ptr;
 
     template<class U>
-    intrusive_ptr(intrusive_ptr<U> && rhs, typename boost::detail::sp_enable_if_convertible<U,T>::type = boost::detail::sp_empty())
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr<U> && rhs, typename boost::detail::sp_enable_if_convertible<U,T>::type = boost::detail::sp_empty())
     : px( rhs.px )
     {
         rhs.px = 0;
     }
 
     template<class U>
-    intrusive_ptr & operator=(intrusive_ptr<U> && rhs) noexcept
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr & operator=(intrusive_ptr<U> && rhs) noexcept
     {
         this_type( static_cast< intrusive_ptr<U> && >( rhs ) ).swap(*this);
         return *this;
     }
 
-    intrusive_ptr & operator=(intrusive_ptr const & rhs)
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr & operator=(intrusive_ptr const & rhs)
     {
         this_type(rhs).swap(*this);
         return *this;
     }
 
-    intrusive_ptr & operator=(T * rhs)
+    BOOST_SP_CXX20_CONSTEXPR intrusive_ptr & operator=(T * rhs)
     {
         this_type(rhs).swap(*this);
         return *this;
     }
 
-    void reset()
+    BOOST_SP_CXX20_CONSTEXPR void reset()
     {
         this_type().swap( *this );
     }
 
-    void reset( T * rhs )
+    BOOST_SP_CXX20_CONSTEXPR void reset( T * rhs )
     {
         this_type( rhs ).swap( *this );
     }
 
-    void reset( T * rhs, bool add_ref )
+    BOOST_SP_CXX20_CONSTEXPR void reset( T * rhs, bool add_ref )
     {
         this_type( rhs, add_ref ).swap( *this );
     }
 
-    T * get() const noexcept
+    BOOST_SP_CXX20_CONSTEXPR T * get() const noexcept
     {
         return px;
     }
 
-    T * detach() noexcept
+    BOOST_SP_CXX20_CONSTEXPR T * detach() noexcept
     {
         T * ret = px;
         px = 0;
         return ret;
     }
 
-    T & operator*() const BOOST_SP_NOEXCEPT_WITH_ASSERT
+    BOOST_SP_CXX20_CONSTEXPR T & operator*() const BOOST_SP_NOEXCEPT_WITH_ASSERT
     {
         BOOST_ASSERT( px != 0 );
         return *px;
     }
 
-    T * operator->() const BOOST_SP_NOEXCEPT_WITH_ASSERT
+    BOOST_SP_CXX20_CONSTEXPR T * operator->() const BOOST_SP_NOEXCEPT_WITH_ASSERT
     {
         BOOST_ASSERT( px != 0 );
         return px;
     }
 
-    explicit operator bool () const noexcept
+    BOOST_SP_CXX20_CONSTEXPR explicit operator bool () const noexcept
     {
         return px != 0;
     }
 
-    void swap(intrusive_ptr & rhs) noexcept
+    BOOST_SP_CXX20_CONSTEXPR void swap(intrusive_ptr & rhs) noexcept
     {
         T * tmp = px;
         px = rhs.px;
@@ -178,101 +179,101 @@ private:
     T * px;
 };
 
-template<class T, class U> inline bool operator==(intrusive_ptr<T> const & a, intrusive_ptr<U> const & b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator==(intrusive_ptr<T> const & a, intrusive_ptr<U> const & b) noexcept
 {
     return a.get() == b.get();
 }
 
-template<class T, class U> inline bool operator!=(intrusive_ptr<T> const & a, intrusive_ptr<U> const & b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator!=(intrusive_ptr<T> const & a, intrusive_ptr<U> const & b) noexcept
 {
     return a.get() != b.get();
 }
 
-template<class T, class U> inline bool operator==(intrusive_ptr<T> const & a, U * b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator==(intrusive_ptr<T> const & a, U * b) noexcept
 {
     return a.get() == b;
 }
 
-template<class T, class U> inline bool operator!=(intrusive_ptr<T> const & a, U * b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator!=(intrusive_ptr<T> const & a, U * b) noexcept
 {
     return a.get() != b;
 }
 
-template<class T, class U> inline bool operator==(T * a, intrusive_ptr<U> const & b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator==(T * a, intrusive_ptr<U> const & b) noexcept
 {
     return a == b.get();
 }
 
-template<class T, class U> inline bool operator!=(T * a, intrusive_ptr<U> const & b) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline bool operator!=(T * a, intrusive_ptr<U> const & b) noexcept
 {
     return a != b.get();
 }
 
-template<class T> inline bool operator==( intrusive_ptr<T> const & p, std::nullptr_t ) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline bool operator==( intrusive_ptr<T> const & p, std::nullptr_t ) noexcept
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator==( std::nullptr_t, intrusive_ptr<T> const & p ) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline bool operator==( std::nullptr_t, intrusive_ptr<T> const & p ) noexcept
 {
     return p.get() == 0;
 }
 
-template<class T> inline bool operator!=( intrusive_ptr<T> const & p, std::nullptr_t ) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline bool operator!=( intrusive_ptr<T> const & p, std::nullptr_t ) noexcept
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator!=( std::nullptr_t, intrusive_ptr<T> const & p ) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline bool operator!=( std::nullptr_t, intrusive_ptr<T> const & p ) noexcept
 {
     return p.get() != 0;
 }
 
-template<class T> inline bool operator<(intrusive_ptr<T> const & a, intrusive_ptr<T> const & b) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline bool operator<(intrusive_ptr<T> const & a, intrusive_ptr<T> const & b) noexcept
 {
     return std::less<T *>()(a.get(), b.get());
 }
 
-template<class T> void swap(intrusive_ptr<T> & lhs, intrusive_ptr<T> & rhs) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline void swap(intrusive_ptr<T> & lhs, intrusive_ptr<T> & rhs) noexcept
 {
     lhs.swap(rhs);
 }
 
 // mem_fn support
 
-template<class T> T * get_pointer(intrusive_ptr<T> const & p) noexcept
+template<class T> BOOST_SP_CXX20_CONSTEXPR inline T * get_pointer(intrusive_ptr<T> const & p) noexcept
 {
     return p.get();
 }
 
 // pointer casts
 
-template<class T, class U> intrusive_ptr<T> static_pointer_cast(intrusive_ptr<U> const & p)
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> static_pointer_cast(intrusive_ptr<U> const & p)
 {
     return static_cast<T *>(p.get());
 }
 
-template<class T, class U> intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U> const & p)
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> const_pointer_cast(intrusive_ptr<U> const & p)
 {
     return const_cast<T *>(p.get());
 }
 
-template<class T, class U> intrusive_ptr<T> dynamic_pointer_cast(intrusive_ptr<U> const & p)
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> dynamic_pointer_cast(intrusive_ptr<U> const & p)
 {
     return dynamic_cast<T *>(p.get());
 }
 
-template<class T, class U> intrusive_ptr<T> static_pointer_cast( intrusive_ptr<U> && p ) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> static_pointer_cast( intrusive_ptr<U> && p ) noexcept
 {
     return intrusive_ptr<T>( static_cast<T*>( p.detach() ), false );
 }
 
-template<class T, class U> intrusive_ptr<T> const_pointer_cast( intrusive_ptr<U> && p ) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> const_pointer_cast( intrusive_ptr<U> && p ) noexcept
 {
     return intrusive_ptr<T>( const_cast<T*>( p.detach() ), false );
 }
 
-template<class T, class U> intrusive_ptr<T> dynamic_pointer_cast( intrusive_ptr<U> && p ) noexcept
+template<class T, class U> BOOST_SP_CXX20_CONSTEXPR inline intrusive_ptr<T> dynamic_pointer_cast( intrusive_ptr<U> && p ) noexcept
 {
     T * p2 = dynamic_cast<T*>( p.get() );
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -245,6 +245,7 @@ run atomic_sp_test.cpp ;
 
 run sp_constexpr_test.cpp ;
 run sp_constexpr_test2.cpp ;
+compile ip_constexpr_test.cpp ;
 
 run atomic_sp_constexpr_test.cpp ;
 

--- a/test/ip_constexpr_test.cpp
+++ b/test/ip_constexpr_test.cpp
@@ -1,0 +1,133 @@
+//
+// ip_constexpr_test.cpp
+//
+// Copyright 2025 Mathias Stearn
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+
+#include <boost/intrusive_ptr.hpp>
+
+#ifndef BOOST_SP_NO_CXX20_CONSTEXPR
+
+struct dummy {
+    // no-ops, so safe on pointers to static constexpr variables
+    friend constexpr void intrusive_ptr_add_ref(const dummy *) {}
+    friend constexpr void intrusive_ptr_release(const dummy *) {}
+};
+static constexpr dummy d;
+
+struct subdummy : dummy {};
+
+// Test that basic operations work at compile time.
+static_assert(bool(boost::intrusive_ptr<const dummy>(&d)));
+static_assert(!bool(boost::intrusive_ptr<dummy>(nullptr)));
+static_assert(!bool(boost::intrusive_ptr<dummy>()));
+static_assert(!bool(boost::intrusive_ptr<dummy>(boost::intrusive_ptr<subdummy>())));
+static_assert(&*boost::intrusive_ptr<const dummy>(&d) == &d);
+static_assert(boost::intrusive_ptr<const dummy>(&d).operator->() == &d);
+static_assert(boost::intrusive_ptr<dummy>() == nullptr);
+static_assert(boost::intrusive_ptr<dummy>() == boost::intrusive_ptr<dummy>(nullptr));
+static_assert(boost::intrusive_ptr<dummy>() != boost::intrusive_ptr<const dummy>(&d));
+static_assert(boost::intrusive_ptr<const dummy>(&d) != nullptr);
+static_assert(boost::intrusive_ptr<const dummy>(&d) == boost::intrusive_ptr<const dummy>(&d));
+static_assert(boost::intrusive_ptr<const dummy>(&d) == boost::intrusive_ptr<const dummy>(&d).get());
+static_assert(boost::intrusive_ptr<const dummy>(&d) == boost::intrusive_ptr<const dummy>(&d).detach());
+static_assert(!(boost::intrusive_ptr<const dummy>(&d) < boost::intrusive_ptr<const dummy>(&d)));
+static_assert(boost::get_pointer(boost::intrusive_ptr<const dummy>(&d)) == &d);
+static_assert(boost::static_pointer_cast<const dummy>( boost::intrusive_ptr<const dummy>(&d)) == &d);
+static_assert(boost::const_pointer_cast<const dummy>( boost::intrusive_ptr<const dummy>(&d)) == &d);
+static_assert(boost::dynamic_pointer_cast<const dummy>( boost::intrusive_ptr<const dummy>(&d)) == &d);
+
+constexpr auto lvalue = boost::intrusive_ptr<const dummy>(&d);
+constexpr auto lvalue_convertible = boost::intrusive_ptr<const subdummy>();
+static_assert(boost::intrusive_ptr<const dummy>(lvalue) == &d);
+static_assert(!boost::intrusive_ptr<const dummy>(lvalue_convertible));
+static_assert(boost::static_pointer_cast<const dummy>(lvalue) == &d);
+static_assert(boost::const_pointer_cast<const dummy>(lvalue) == &d);
+static_assert(boost::dynamic_pointer_cast<const dummy>(lvalue) == &d);
+
+// Works in places that static_assert doesn't, like expressions with
+// non-constexpr variables in constexpr functions.
+template <typename T> constexpr void semi_static_assert(T b) {
+    if (!b)
+        throw "assertion failed"; // Not constexpr so fails compile.
+}
+
+constexpr bool test_swap() {
+    auto p1 = boost::intrusive_ptr<const dummy>(&d);
+    auto p2 = boost::intrusive_ptr<const dummy>();
+    swap(p1, p2);
+    semi_static_assert(!p1 && p2);
+    p1.swap(p2);
+    semi_static_assert(p1 && !p2);
+    return true;
+}
+static_assert(test_swap());
+
+constexpr bool test_reset_assign() {
+    // Test assignments resulting in nullptr
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1.reset();
+        semi_static_assert(!p1);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1.reset(nullptr);
+        semi_static_assert(!p1);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1 = nullptr;
+        semi_static_assert(!p1);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1 = boost::intrusive_ptr<const dummy>();
+        semi_static_assert(!p1);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1 = boost::intrusive_ptr<subdummy>();
+        semi_static_assert(!p1);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>(&d);
+        p1 = lvalue_convertible;
+        semi_static_assert(!p1);
+    }
+
+    // Test assignments resulting in &d
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>();
+        p1.reset(&d);
+        semi_static_assert(p1 == &d);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>();
+        p1.reset(&d, true);
+        semi_static_assert(p1 == &d);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>();
+        p1 = boost::intrusive_ptr<const dummy>(&d);
+        semi_static_assert(p1 == &d);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>();
+        p1 = lvalue;
+        semi_static_assert(p1 == &d);
+    }
+    {
+        auto p1 = boost::intrusive_ptr<const dummy>();
+        p1 = &d;
+        semi_static_assert(p1 == &d);
+    }
+    return true;
+}
+static_assert(test_reset_assign());
+
+#endif


### PR DESCRIPTION
I opted for the maximalist approach of making anything that could reasonably be constexpr be so. That means everything other than working with ostream is now. I also added inline to the free-functions that were not already marked as such but were being made constexpr because constexpr implies inline on functions. It felt wrong for a function's inlineness to depend on which C++ standard you compile with. It mostly doesn't matter because the functions were already templates.

Fixes #117