### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,6 @@ install:
   - git submodule init libs/core
   - git submodule init libs/move
   - git submodule init libs/predef
-  - git submodule init libs/static_assert
   - git submodule init libs/throw_exception
   - git submodule init libs/type_traits
   - git submodule init libs/detail

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -11,7 +11,6 @@ add_subdirectory(../../../assert boostorg/assert)
 add_subdirectory(../../../config boostorg/config)
 add_subdirectory(../../../core boostorg/core)
 add_subdirectory(../../../move boostorg/move)
-add_subdirectory(../../../static_assert boostorg/static_assert)
 add_subdirectory(../../../throw_exception boostorg/throw_exception)
 add_subdirectory(../../../type_traits boostorg/type_traits)
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.